### PR TITLE
Made the block size generic using generic-array

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,4 @@ categories = ["cryptography"]
 subtle = "2.5"
 rand = "0.8"
 aligned = "0.4"
-generic-array = "1.0"
-
+generic-array = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,8 @@ use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeLess, 
 
 type IndexType = usize;
 
-/// Represents an oblivious RAM mapping `IndexType` addresses to `BlockValue` values.
+/// Represents an oblivious RAM (ORAM) mapping `IndexType` addresses to `BlockValue` values.
+/// `B` represents the size of each block of the ORAM in bytes.
 pub trait ORAM<B: ArrayLength> {
     /// Returns a new ORAM mapping addresses `0 <= address <= block_capacity` to default `BlockValue` values.
     fn new(block_capacity: IndexType) -> Self;


### PR DESCRIPTION
Made the block size of the ORAM a configurable parameter. This was achieved by changing the representation of ORAM blocks from (a wrapper around) a fixed-size array to (a wrapper around) a `GenericArray` from the `generic-array` crate.