### PR TITLE
Added linear workload tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,11 +263,12 @@ mod tests {
 
     #[test]
     fn check_alignment() {
-        const BLOCK_CAPACITY: usize = 256;
+        let irrelevant_capacity = 256;
+        let expected_alignment = 64;
         let oram: LinearTimeORAM<SimpleDatabase<BlockValue<64>>> =
-            LinearTimeORAM::new(BLOCK_CAPACITY);
+            LinearTimeORAM::new(irrelevant_capacity);
         for block in &oram.physical_memory.0 {
-            assert_eq!(mem::align_of_val(block), 64);
+            assert_eq!(mem::align_of_val(block), expected_alignment);
         }
     }
 


### PR DESCRIPTION
- Added more random access pattern correctness tests corresponding to ORAMs of different block sizes and capacities.
- Added a parallel set of "linear access pattern" correctness tests that repeatedly access indices in order 1, 2, ... N; this is known to be the worst-case access pattern in terms of stash occupancy [see the original PathORAM paper](https://eprint.iacr.org/2013/280.pdf).