### PR TITLE
Smaller tests

### DIFF
--- a/src/linear_time_oram.rs
+++ b/src/linear_time_oram.rs
@@ -96,7 +96,8 @@ mod tests {
     use super::*;
     use crate::{
         test_utils::{
-            create_correctness_test, test_correctness_linear_workload,
+            create_correctness_test, create_correctness_tests_for_oram_type,
+            create_correctness_tests_for_workload_and_oram_type, test_correctness_linear_workload,
             test_correctness_random_workload,
         },
         SimpleDatabase,
@@ -113,90 +114,5 @@ mod tests {
         }
     }
 
-    // Block size 64 bytes, block capacity 256 bytes, testing with 10000 operations
-    create_correctness_test!(
-        test_correctness_random_workload,
-        ConcreteLinearTimeOram,
-        64,
-        256,
-        10000
-    );
-    create_correctness_test!(
-        test_correctness_random_workload,
-        ConcreteLinearTimeOram,
-        1,
-        64,
-        10000
-    );
-    create_correctness_test!(
-        test_correctness_random_workload,
-        ConcreteLinearTimeOram,
-        64,
-        1,
-        10000
-    );
-    create_correctness_test!(
-        test_correctness_random_workload,
-        ConcreteLinearTimeOram,
-        64,
-        64,
-        10000
-    );
-    create_correctness_test!(
-        test_correctness_random_workload,
-        ConcreteLinearTimeOram,
-        4096,
-        64,
-        1000
-    );
-    create_correctness_test!(
-        test_correctness_random_workload,
-        ConcreteLinearTimeOram,
-        4096,
-        256,
-        1000
-    );
-
-    create_correctness_test!(
-        test_correctness_linear_workload,
-        ConcreteLinearTimeOram,
-        64,
-        256,
-        100
-    );
-    create_correctness_test!(
-        test_correctness_linear_workload,
-        ConcreteLinearTimeOram,
-        1,
-        64,
-        100
-    );
-    create_correctness_test!(
-        test_correctness_linear_workload,
-        ConcreteLinearTimeOram,
-        64,
-        1,
-        100
-    );
-    create_correctness_test!(
-        test_correctness_linear_workload,
-        ConcreteLinearTimeOram,
-        64,
-        64,
-        100
-    );
-    create_correctness_test!(
-        test_correctness_linear_workload,
-        ConcreteLinearTimeOram,
-        4096,
-        64,
-        10
-    );
-    create_correctness_test!(
-        test_correctness_linear_workload,
-        ConcreteLinearTimeOram,
-        4096,
-        256,
-        2
-    );
+    create_correctness_tests_for_oram_type!(ConcreteLinearTimeOram);
 }

--- a/src/simple_insecure_path_oram.rs
+++ b/src/simple_insecure_path_oram.rs
@@ -64,6 +64,7 @@ impl<const B: BlockSize, const Z: BucketSizeType> Oram<B> for SimpleInsecurePath
         assert!(block_capacity > 1);
 
         let number_of_nodes = block_capacity;
+
         let height = block_capacity.ilog2() - 1;
         assert!(height <= MAXIMUM_TREE_HEIGHT);
 
@@ -325,79 +326,12 @@ pub type ConcreteSimpleInsecurePathOram<const B: BlockSize> =
 #[cfg(test)]
 mod tests {
     use crate::test_utils::{
-        create_correctness_test, test_correctness_linear_workload, test_correctness_random_workload,
+        create_correctness_test, create_correctness_tests_for_oram_type,
+        create_correctness_tests_for_workload_and_oram_type, test_correctness_linear_workload,
+        test_correctness_random_workload,
     };
 
     use super::ConcreteSimpleInsecurePathOram;
-    create_correctness_test!(
-        test_correctness_random_workload,
-        ConcreteSimpleInsecurePathOram,
-        64,
-        256,
-        500
-    );
-    create_correctness_test!(
-        test_correctness_random_workload,
-        ConcreteSimpleInsecurePathOram,
-        1,
-        64,
-        1000
-    );
-    create_correctness_test!(
-        test_correctness_random_workload,
-        ConcreteSimpleInsecurePathOram,
-        64,
-        64,
-        1000
-    );
-    create_correctness_test!(
-        test_correctness_random_workload,
-        ConcreteSimpleInsecurePathOram,
-        4096,
-        64,
-        500
-    );
-    create_correctness_test!(
-        test_correctness_random_workload,
-        ConcreteSimpleInsecurePathOram,
-        4096,
-        256,
-        500
-    );
 
-    create_correctness_test!(
-        test_correctness_linear_workload,
-        ConcreteSimpleInsecurePathOram,
-        64,
-        256,
-        2
-    );
-    create_correctness_test!(
-        test_correctness_linear_workload,
-        ConcreteSimpleInsecurePathOram,
-        1,
-        64,
-        10
-    );
-    create_correctness_test!(
-        test_correctness_linear_workload,
-        ConcreteSimpleInsecurePathOram,
-        64,
-        64,
-        10
-    );
-    create_correctness_test!(
-        test_correctness_linear_workload,
-        ConcreteSimpleInsecurePathOram,
-        4096,
-        64,
-        2
-    );
-    create_correctness_test!(
-        test_correctness_linear_workload,
-        ConcreteSimpleInsecurePathOram,
-        4096,
-        256,
-        2
-    );
+    create_correctness_tests_for_oram_type!(ConcreteSimpleInsecurePathOram);
 }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -47,13 +47,15 @@ pub(crate) fn test_correctness_random_workload<const B: usize, T: Oram<B>>(
 /// Tests the correctness of an `Oram` type T on repeated passes of sequential accesses 0, 1, ..., `capacity`
 pub(crate) fn test_correctness_linear_workload<const B: usize, T: Oram<B>>(
     capacity: usize,
-    num_passes: u32,
+    num_operations: u32,
 ) {
     let mut rng = StdRng::seed_from_u64(0);
 
     let mut oram = T::new(capacity, &mut rng);
 
     let mut mirror_array = vec![BlockValue::default(); capacity];
+
+    let num_passes = (num_operations as usize) / capacity;
 
     for _ in 0..num_passes {
         for index in 0..capacity {
@@ -86,4 +88,35 @@ macro_rules! create_correctness_test {
     };
 }
 
+macro_rules! create_correctness_tests_for_workload_and_oram_type {
+    ($function_name: ident, $oram_type: ident) => {
+        create_correctness_test!($function_name, $oram_type, 1, 2, 10);
+        create_correctness_test!($function_name, $oram_type, 8, 2, 10);
+        create_correctness_test!($function_name, $oram_type, 16, 2, 100);
+        create_correctness_test!($function_name, $oram_type, 1, 16, 100);
+        create_correctness_test!($function_name, $oram_type, 8, 16, 100);
+        create_correctness_test!($function_name, $oram_type, 16, 16, 100);
+        create_correctness_test!($function_name, $oram_type, 1, 32, 100);
+        create_correctness_test!($function_name, $oram_type, 1, 32, 1000);
+        create_correctness_test!($function_name, $oram_type, 8, 32, 100);
+        // Block size 16 bytes, block capacity 32 blocks, testing with 100 operations
+        create_correctness_test!($function_name, $oram_type, 16, 32, 100);
+    };
+}
+
+macro_rules! create_correctness_tests_for_oram_type {
+    ($oram_type: ident) => {
+        create_correctness_tests_for_workload_and_oram_type!(
+            test_correctness_linear_workload,
+            $oram_type
+        );
+        create_correctness_tests_for_workload_and_oram_type!(
+            test_correctness_random_workload,
+            $oram_type
+        );
+    };
+}
+
 pub(crate) use create_correctness_test;
+pub(crate) use create_correctness_tests_for_oram_type;
+pub(crate) use create_correctness_tests_for_workload_and_oram_type;


### PR DESCRIPTION
- Deduplicated tests across ORAM types. Test parameters are now defined only once, in `test_utils::create_correctness_tests_for_workload_and_oram_type`.
- Made the test parameters smaller so that the tests run in a little over 1 second on my machine.