### PR TITLE
Rewrote oblivious stash

### DIFF
--- a/src/path_oram/recursive_secure_path_oram.rs
+++ b/src/path_oram/recursive_secure_path_oram.rs
@@ -28,8 +28,6 @@ pub type ConcreteObliviousAddressOram<const AB: BlockSize, V> = GenericPathOram<
 pub type ConcreteObliviousBlockOram<const B: BlockSize, V> =
     BlockOram<B, V, DEFAULT_BLOCKS_PER_BUCKET, BitonicStash<AddressOramBlock<B>>, BitonicStash<V>>;
 
-// REVIEW NOTE: The rest of this file has already been reviewed. The only difference from a previous version is
-// the concrete ORAM structs being tested.
 #[cfg(test)]
 mod address_oram_tests {
     use super::*;

--- a/src/path_oram/tree_index.rs
+++ b/src/path_oram/tree_index.rs
@@ -16,7 +16,7 @@ pub trait CompleteBinaryTreeIndex {
     fn random_leaf<R: RngCore + CryptoRng>(tree_height: TreeHeight, rng: &mut R) -> Self;
     fn depth(&self) -> TreeHeight;
     fn is_leaf(&self, height: TreeHeight) -> bool;
-    fn common_ancestor_of_two_leaves(&self, other: Self) -> Self;
+    fn ct_common_ancestor_of_two_leaves(&self, other: Self) -> Self;
 }
 
 impl CompleteBinaryTreeIndex for TreeIndex {
@@ -43,7 +43,7 @@ impl CompleteBinaryTreeIndex for TreeIndex {
         self.depth() == height
     }
 
-    fn common_ancestor_of_two_leaves(&self, other: Self) -> Self {
+    fn ct_common_ancestor_of_two_leaves(&self, other: Self) -> Self {
         // The two inputs must be of the same height.
         assert_eq!(self.leading_zeros(), other.leading_zeros());
         let shared_prefix_length = (self ^ other).leading_zeros();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -11,7 +11,6 @@ use crate::path_oram::bitonic_sort::bitonic_sort_by_keys;
 use rand::seq::SliceRandom;
 use rand::{CryptoRng, RngCore};
 
-// REVIEW NOTE: This function has already been reviewed.
 pub(crate) fn random_permutation_of_0_through_n_exclusive<R: RngCore + CryptoRng>(
     n: u64,
     rng: &mut R,


### PR DESCRIPTION
Rewrote the oblivious stash `BitonicStash`. The new version is actually oblivious (addressing #28) and about twice as fast. The rewrite also involved a small modification to the `Stash` API.