### PR TITLE
U64ize

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,8 @@ paste = "1"
 duplicate = "1"
 simplelog = "0.12"
 log = "0.4"
-thiserror = "1.0"
+thiserror = "1"
+static_assertions = "1.1"
 
 [dev-dependencies]
 criterion = { version = "0.4", features = ["html_reports"] }

--- a/benches/README.md
+++ b/benches/README.md
@@ -6,103 +6,306 @@ Use `cargo bench` to run benchmarks.
 
 ```
 % cargo bench
-Running benches/benchmark.rs (target/release/deps/benchmark-0372a3041da7f352)
-LinearTimeOram::read/(Capacity: 16384 Blocksize: 4096)
-                        time:   [9.1764 ms 9.2246 ms 9.2783 ms]
-                        change: [-12.509% -11.377% -10.272%] (p = 0.00 < 0.05)
-                        Performance has improved.
-Benchmarking LinearTimeOram::read/(Capacity: 65536 Blocksize: 4096): Warming up for 100.00 ms
-Warning: Unable to complete 10 samples in 100.0ms. You may wish to increase target time to 407.7ms.
-LinearTimeOram::read/(Capacity: 65536 Blocksize: 4096)
-                        time:   [36.470 ms 36.788 ms 37.225 ms]
-                        change: [-14.398% -12.615% -10.898%] (p = 0.00 < 0.05)
-                        Performance has improved.
-Found 1 outliers among 10 measurements (10.00%)
-  1 (10.00%) high severe
-Benchmarking LinearTimeOram::read/(Capacity: 1048576 Blocksize: 4096): Warming up for 100.00 ms
-Warning: Unable to complete 10 samples in 100.0ms. You may wish to increase target time to 17.5s.
-LinearTimeOram::read/(Capacity: 1048576 Blocksize: 4096)
-                        time:   [601.12 ms 662.39 ms 762.15 ms]
-                        change: [-10.865% -1.3507% +15.145%] (p = 0.88 > 0.05)
+Running benches/benchmark.rs (target/release/deps/benchmark-c0e9411356248ba6)
+LinearTimeOram::initialization/(Capacity: 64 Blocksize: 64)
+                        time:   [66.619 ns 67.973 ns 69.590 ns]
+                        change: [+0.2232% +4.1831% +8.2459%] (p = 0.04 < 0.05)
+                        Change within noise threshold.
+Found 11 outliers among 100 measurements (11.00%)
+  7 (7.00%) high mild
+  4 (4.00%) high severe
+LinearTimeOram::initialization/(Capacity: 256 Blocksize: 64)
+                        time:   [212.72 ns 223.59 ns 235.90 ns]
+                        change: [-11.858% -6.0727% +1.6889%] (p = 0.08 > 0.05)
                         No change in performance detected.
-Found 1 outliers among 10 measurements (10.00%)
-  1 (10.00%) high severe
+Found 9 outliers among 100 measurements (9.00%)
+  4 (4.00%) high mild
+  5 (5.00%) high severe
 
-RecursiveSecureOram::read/(Capacity: 16384 Blocksize: 4096)
-                        time:   [1.1581 ms 1.1600 ms 1.1620 ms]
-                        change: [-12.640% -11.624% -10.601%] (p = 0.00 < 0.05)
-                        Performance has improved.
-Found 1 outliers among 10 measurements (10.00%)
-  1 (10.00%) high mild
-RecursiveSecureOram::read/(Capacity: 65536 Blocksize: 4096)
-                        time:   [1.3746 ms 1.4106 ms 1.4715 ms]
-                        change: [-9.6176% -7.3772% -4.2653%] (p = 0.00 < 0.05)
-                        Performance has improved.
-Found 1 outliers among 10 measurements (10.00%)
-  1 (10.00%) high severe
-RecursiveSecureOram::read/(Capacity: 1048576 Blocksize: 4096)
-                        time:   [4.9352 ms 4.9622 ms 4.9939 ms]
-                        change: [-21.182% -16.699% -12.677%] (p = 0.00 < 0.05)
-                        Performance has improved.
-Found 1 outliers among 10 measurements (10.00%)
-  1 (10.00%) high mild
-
-LinearTimeOram::initialization/(Capacity: 16384 Blocksize: 4096)
-                        time:   [8.0183 ms 8.2087 ms 8.3918 ms]
-                        change: [+8.6264% +12.309% +16.306%] (p = 0.00 < 0.05)
+LinearTimeOram::initialization/(Capacity: 64 Blocksize: 4096)
+                        time:   [3.6845 µs 3.9785 µs 4.2586 µs]
+                        change: [+4.4178% +13.170% +23.508%] (p = 0.00 < 0.05)
                         Performance has regressed.
-Benchmarking LinearTimeOram::initialization/(Capacity: 65536 Blocksize: 4096): Warming up for 100.00 ms
-Warning: Unable to complete 10 samples in 100.0ms. You may wish to increase target time to 310.0ms.
-LinearTimeOram::initialization/(Capacity: 65536 Blocksize: 4096)
-                        time:   [32.430 ms 33.623 ms 35.165 ms]
-                        change: [-7.8815% -4.1354% +0.2933%] (p = 0.09 > 0.05)
+LinearTimeOram::initialization/(Capacity: 256 Blocksize: 4096)
+                        time:   [12.311 µs 13.262 µs 14.343 µs]
+                        change: [-12.499% -4.1684% +4.2933%] (p = 0.32 > 0.05)
                         No change in performance detected.
-Found 1 outliers among 10 measurements (10.00%)
-  1 (10.00%) high mild
-Benchmarking LinearTimeOram::initialization/(Capacity: 1048576 Blocksize: 4096): Warming up for 100.00 ms
-Warning: Unable to complete 10 samples in 100.0ms. You may wish to increase target time to 4.2s.
-LinearTimeOram::initialization/(Capacity: 1048576 Blocksize: 4096)
-                        time:   [417.29 ms 422.91 ms 429.42 ms]
-                        change: [-8.8642% -5.6243% -2.5261%] (p = 0.00 < 0.05)
-                        Performance has improved.
-Found 3 outliers among 10 measurements (30.00%)
-  1 (10.00%) low mild
-  2 (20.00%) high severe
 
-Benchmarking RecursiveSecureOram::initialization/(Capacity: 16384 Blocksize: 4096): Warming up for 100.00 ms
-Warning: Unable to complete 10 samples in 100.0ms. You may wish to increase target time to 490.9ms.
-RecursiveSecureOram::initialization/(Capacity: 16384 Blocksize: 4096)
-                        time:   [50.339 ms 50.929 ms 51.417 ms]
-                        change: [-20.147% -11.930% -6.2350%] (p = 0.01 < 0.05)
-                        Performance has improved.
-Found 2 outliers among 10 measurements (20.00%)
-  2 (20.00%) low mild
-Benchmarking RecursiveSecureOram::initialization/(Capacity: 65536 Blocksize: 4096): Warming up for 100.00 ms
-Warning: Unable to complete 10 samples in 100.0ms. You may wish to increase target time to 2.0s.
-RecursiveSecureOram::initialization/(Capacity: 65536 Blocksize: 4096)
-                        time:   [194.39 ms 194.83 ms 195.19 ms]
-                        change: [-2.4988% -1.7890% -1.0964%] (p = 0.00 < 0.05)
-                        Performance has improved.
-Found 3 outliers among 10 measurements (30.00%)
-  1 (10.00%) low severe
-  2 (20.00%) high mild
-Benchmarking RecursiveSecureOram::initialization/(Capacity: 1048576 Blocksize: 4096): Warming up for 100.00 ms
-Warning: Unable to complete 10 samples in 100.0ms. You may wish to increase target time to 63.6s.
-RecursiveSecureOram::initialization/(Capacity: 1048576 Blocksize: 4096)
-                        time:   [6.3310 s 6.4535 s 6.6195 s]
-                        change: [-7.1614% -4.4196% -1.2474%] (p = 0.02 < 0.05)
-                        Performance has improved.
-Found 1 outliers among 10 measurements (10.00%)
-  1 (10.00%) high severe
+LinearTimeOram::read/(Capacity: 64 Blocksize: 64)
+                        time:   [293.91 ns 296.46 ns 301.13 ns]
+                        change: [+3.7833% +4.6460% +5.9849%] (p = 0.00 < 0.05)
+                        Performance has regressed.
+Found 1 outliers among 100 measurements (1.00%)
+  1 (1.00%) high severe
+LinearTimeOram::read/(Capacity: 256 Blocksize: 64)
+                        time:   [1.0843 µs 1.0916 µs 1.1028 µs]
+                        change: [+1.8924% +4.2521% +7.6769%] (p = 0.00 < 0.05)
+                        Performance has regressed.
+Found 16 outliers among 100 measurements (16.00%)
+  1 (1.00%) low mild
+  13 (13.00%) high mild
+  2 (2.00%) high severe
+
+LinearTimeOram::read/(Capacity: 64 Blocksize: 4096)
+                        time:   [43.301 µs 43.401 µs 43.526 µs]
+                        change: [-7.0116% -1.8092% +1.7788%] (p = 0.61 > 0.05)
+                        No change in performance detected.
+Found 10 outliers among 100 measurements (10.00%)
+  1 (1.00%) low severe
+  2 (2.00%) low mild
+  3 (3.00%) high mild
+  4 (4.00%) high severe
+LinearTimeOram::read/(Capacity: 256 Blocksize: 4096)
+                        time:   [169.20 µs 169.80 µs 170.56 µs]
+                        change: [+1.6632% +2.1063% +2.5624%] (p = 0.00 < 0.05)
+                        Performance has regressed.
+Found 11 outliers among 100 measurements (11.00%)
+  2 (2.00%) low mild
+  4 (4.00%) high mild
+  5 (5.00%) high severe
+
+LinearTimeOram::write/(Capacity: 64 Blocksize: 64)
+                        time:   [275.86 ns 276.25 ns 276.70 ns]
+                        change: [+1.5245% +2.0471% +2.4350%] (p = 0.00 < 0.05)
+                        Performance has regressed.
+Found 23 outliers among 100 measurements (23.00%)
+  3 (3.00%) low severe
+  3 (3.00%) low mild
+  6 (6.00%) high mild
+  11 (11.00%) high severe
+LinearTimeOram::write/(Capacity: 256 Blocksize: 64)
+                        time:   [1.0674 µs 1.0688 µs 1.0706 µs]
+                        change: [-1.8993% -0.3239% +0.6033%] (p = 0.77 > 0.05)
+                        No change in performance detected.
+Found 23 outliers among 100 measurements (23.00%)
+  4 (4.00%) low severe
+  5 (5.00%) low mild
+  2 (2.00%) high mild
+  12 (12.00%) high severe
+
+LinearTimeOram::write/(Capacity: 64 Blocksize: 4096)
+                        time:   [42.755 µs 42.809 µs 42.869 µs]
+                        change: [-0.9097% +0.7446% +1.8029%] (p = 0.38 > 0.05)
+                        No change in performance detected.
+Found 8 outliers among 100 measurements (8.00%)
+  1 (1.00%) low severe
+  2 (2.00%) low mild
+  3 (3.00%) high mild
+  2 (2.00%) high severe
+LinearTimeOram::write/(Capacity: 256 Blocksize: 4096)
+                        time:   [170.36 µs 174.95 µs 180.99 µs]
+                        change: [+1.4177% +3.5344% +6.0682%] (p = 0.00 < 0.05)
+                        Performance has regressed.
+Found 11 outliers among 100 measurements (11.00%)
+  2 (2.00%) low mild
+  9 (9.00%) high severe
+
+LinearTimeOram::random_operations/(Capacity: 64 Blocksize: 64, Ops: 64)
+                        time:   [18.025 µs 18.050 µs 18.081 µs]
+                        change: [-0.2062% +0.6009% +1.2096%] (p = 0.10 > 0.05)
+                        No change in performance detected.
+Found 9 outliers among 100 measurements (9.00%)
+  1 (1.00%) low severe
+  1 (1.00%) low mild
+  3 (3.00%) high mild
+  4 (4.00%) high severe
+LinearTimeOram::random_operations/(Capacity: 256 Blocksize: 64, Ops: 64)
+                        time:   [68.797 µs 68.942 µs 69.102 µs]
+                        change: [+0.7674% +1.0205% +1.2420%] (p = 0.00 < 0.05)
+                        Change within noise threshold.
+Found 9 outliers among 100 measurements (9.00%)
+  2 (2.00%) low severe
+  2 (2.00%) high mild
+  5 (5.00%) high severe
+
+LinearTimeOram::random_operations/(Capacity: 64 Blocksize: 4096, Ops: 64)
+                        time:   [2.7431 ms 2.7468 ms 2.7507 ms]
+                        change: [+0.1405% +1.2075% +1.8350%] (p = 0.00 < 0.05)
+                        Change within noise threshold.
+Found 4 outliers among 100 measurements (4.00%)
+  2 (2.00%) high mild
+  2 (2.00%) high severe
+LinearTimeOram::random_operations/(Capacity: 256 Blocksize: 4096, Ops: 64)
+                        time:   [10.842 ms 10.853 ms 10.865 ms]
+                        change: [-0.5816% -0.0661% +0.3168%] (p = 0.81 > 0.05)
+                        No change in performance detected.
+Found 3 outliers among 100 measurements (3.00%)
+  1 (1.00%) high mild
+  2 (2.00%) high severe
 
 Physical reads and writes incurred by 1 LinearTimeOram::read:
 ORAM Capacity   | ORAM Blocksize  | Physical Reads  | Physical Writes
-16384           | 4096            | 16384           | 16384          
-65536           | 4096            | 65536           | 65536          
-1048576         | 4096            | 1048576         | 1048576        
-Physical reads and writes incurred by 1 RecursiveSecureOram::read:
+64              | 64              | 64              | 64             
+256             | 64              | 256             | 256            
+64              | 4096            | 64              | 64             
+256             | 4096            | 256             | 256            
+
+Physical reads and writes incurred by 1 LinearTimeOram::write:
 ORAM Capacity   | ORAM Blocksize  | Physical Reads  | Physical Writes
-16384           | 4096            | 14              | 14             
-65536           | 4096            | 16              | 16             
-1048576         | 4096            | 20              | 20     
+64              | 64              | 64              | 64             
+256             | 64              | 256             | 256            
+64              | 4096            | 64              | 64             
+256             | 4096            | 256             | 256            
+
+Physical reads and writes incurred by 64 random LinearTimeOram operations:
+ORAM Capacity   | ORAM Blocksize  | Physical Reads  | Physical Writes
+64              | 64              | 4096            | 4096           
+256             | 64              | 16384           | 16384          
+64              | 4096            | 4096            | 4096           
+256             | 4096            | 16384           | 16384          
+VecPathOram::initialization/(Capacity: 64 Blocksize: 64)
+                        time:   [14.776 µs 15.115 µs 15.423 µs]
+                        change: [-5.9812% -3.1459% -0.5428%] (p = 0.03 < 0.05)
+                        Change within noise threshold.
+Found 1 outliers among 100 measurements (1.00%)
+  1 (1.00%) high mild
+VecPathOram::initialization/(Capacity: 256 Blocksize: 64)
+                        time:   [77.748 µs 80.536 µs 83.473 µs]
+                        change: [-2.6343% +2.0805% +6.8860%] (p = 0.39 > 0.05)
+                        No change in performance detected.
+Found 2 outliers among 100 measurements (2.00%)
+  1 (1.00%) high mild
+  1 (1.00%) high severe
+
+VecPathOram::initialization/(Capacity: 64 Blocksize: 4096)
+                        time:   [101.55 µs 104.35 µs 108.57 µs]
+                        change: [+0.7226% +3.9578% +8.0572%] (p = 0.02 < 0.05)
+                        Change within noise threshold.
+Found 3 outliers among 100 measurements (3.00%)
+  1 (1.00%) high mild
+  2 (2.00%) high severe
+VecPathOram::initialization/(Capacity: 256 Blocksize: 4096)
+                        time:   [478.85 µs 490.71 µs 501.74 µs]
+                        change: [+7.6267% +12.171% +16.204%] (p = 0.00 < 0.05)
+                        Performance has regressed.
+
+VecPathOram::read/(Capacity: 64 Blocksize: 64)
+                        time:   [20.581 µs 20.629 µs 20.685 µs]
+                        change: [-3.2297% -0.3683% +1.4998%] (p = 0.83 > 0.05)
+                        No change in performance detected.
+Found 20 outliers among 100 measurements (20.00%)
+  1 (1.00%) low severe
+  1 (1.00%) low mild
+  2 (2.00%) high mild
+  16 (16.00%) high severe
+VecPathOram::read/(Capacity: 256 Blocksize: 64)
+                        time:   [87.103 µs 87.290 µs 87.504 µs]
+                        change: [+1.4341% +1.8262% +2.2138%] (p = 0.00 < 0.05)
+                        Performance has regressed.
+Found 16 outliers among 100 measurements (16.00%)
+  1 (1.00%) low severe
+  1 (1.00%) low mild
+  6 (6.00%) high mild
+  8 (8.00%) high severe
+
+Benchmarking VecPathOram::read/(Capacity: 64 Blocksize: 4096): Warming up for 3.0000 s
+Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.7s, enable flat sampling, or reduce sample count to 60.
+VecPathOram::read/(Capacity: 64 Blocksize: 4096)
+                        time:   [1.1239 ms 1.1264 ms 1.1294 ms]
+                        change: [-11.206% -4.5354% -0.1075%] (p = 0.16 > 0.05)
+                        No change in performance detected.
+Found 16 outliers among 100 measurements (16.00%)
+  13 (13.00%) high mild
+  3 (3.00%) high severe
+VecPathOram::read/(Capacity: 256 Blocksize: 4096)
+                        time:   [4.8769 ms 4.8924 ms 4.9129 ms]
+                        change: [-0.1595% +0.4406% +1.0812%] (p = 0.16 > 0.05)
+                        No change in performance detected.
+Found 3 outliers among 100 measurements (3.00%)
+  2 (2.00%) high mild
+  1 (1.00%) high severe
+
+VecPathOram::write/(Capacity: 64 Blocksize: 64)
+                        time:   [20.633 µs 20.669 µs 20.706 µs]
+                        change: [+1.4562% +1.7694% +2.0853%] (p = 0.00 < 0.05)
+                        Performance has regressed.
+Found 7 outliers among 100 measurements (7.00%)
+  1 (1.00%) low severe
+  5 (5.00%) high mild
+  1 (1.00%) high severe
+VecPathOram::write/(Capacity: 256 Blocksize: 64)
+                        time:   [87.523 µs 87.675 µs 87.833 µs]
+                        change: [+0.6092% +0.9128% +1.2965%] (p = 0.00 < 0.05)
+                        Change within noise threshold.
+Found 2 outliers among 100 measurements (2.00%)
+  1 (1.00%) high mild
+  1 (1.00%) high severe
+
+Benchmarking VecPathOram::write/(Capacity: 64 Blocksize: 4096): Warming up for 3.0000 s
+Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 6.0s, enable flat sampling, or reduce sample count to 60.
+VecPathOram::write/(Capacity: 64 Blocksize: 4096)
+                        time:   [1.1261 ms 1.1278 ms 1.1298 ms]
+                        change: [-1.8599% -0.2878% +0.8158%] (p = 0.75 > 0.05)
+                        No change in performance detected.
+Found 9 outliers among 100 measurements (9.00%)
+  1 (1.00%) low mild
+  6 (6.00%) high mild
+  2 (2.00%) high severe
+VecPathOram::write/(Capacity: 256 Blocksize: 4096)
+                        time:   [4.8705 ms 4.8761 ms 4.8823 ms]
+                        change: [+0.2058% +0.8607% +1.3014%] (p = 0.00 < 0.05)
+                        Change within noise threshold.
+Found 6 outliers among 100 measurements (6.00%)
+  4 (4.00%) high mild
+  2 (2.00%) high severe
+
+Benchmarking VecPathOram::random_operations/(Capacity: 64 Blocksize: 64, Ops: 64): Warming up for 3.0000 s
+Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 6.7s, enable flat sampling, or reduce sample count to 60.
+VecPathOram::random_operations/(Capacity: 64 Blocksize: 64, Ops: 64)
+                        time:   [1.3177 ms 1.3201 ms 1.3231 ms]
+                        change: [+0.7395% +1.0967% +1.4394%] (p = 0.00 < 0.05)
+                        Change within noise threshold.
+Found 11 outliers among 100 measurements (11.00%)
+  1 (1.00%) low severe
+  1 (1.00%) low mild
+  6 (6.00%) high mild
+  3 (3.00%) high severe
+VecPathOram::random_operations/(Capacity: 256 Blocksize: 64, Ops: 64)
+                        time:   [3.6720 ms 3.6826 ms 3.6991 ms]
+                        change: [-3.2277% -0.5866% +0.9930%] (p = 0.77 > 0.05)
+                        No change in performance detected.
+Found 7 outliers among 100 measurements (7.00%)
+  6 (6.00%) high mild
+  1 (1.00%) high severe
+
+Benchmarking VecPathOram::random_operations/(Capacity: 64 Blocksize: 4096, Ops: 64): Warming up for 3.0000 s
+Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 7.2s, or reduce sample count to 60.
+VecPathOram::random_operations/(Capacity: 64 Blocksize: 4096, Ops: 64)
+                        time:   [72.102 ms 72.292 ms 72.605 ms]
+                        change: [+1.3935% +1.7063% +2.1581%] (p = 0.00 < 0.05)
+                        Performance has regressed.
+Found 10 outliers among 100 measurements (10.00%)
+  1 (1.00%) low mild
+  5 (5.00%) high mild
+  4 (4.00%) high severe
+Benchmarking VecPathOram::random_operations/(Capacity: 256 Blocksize: 4096, Ops: 64): Warming up for 3.0000 s
+Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 20.1s, or reduce sample count to 20.
+VecPathOram::random_operations/(Capacity: 256 Blocksize: 4096, Ops: 64)
+                        time:   [209.62 ms 209.81 ms 210.05 ms]
+                        change: [+0.8107% +1.0270% +1.2406%] (p = 0.00 < 0.05)
+                        Change within noise threshold.
+Found 3 outliers among 100 measurements (3.00%)
+  2 (2.00%) high mild
+  1 (1.00%) high severe
+
+Physical reads and writes incurred by 1 VecPathOram::read:
+ORAM Capacity   | ORAM Blocksize  | Physical Reads  | Physical Writes
+64              | 64              | 6               | 6              
+256             | 64              | 8               | 8              
+64              | 4096            | 6               | 6              
+256             | 4096            | 8               | 8              
+
+Physical reads and writes incurred by 1 VecPathOram::write:
+ORAM Capacity   | ORAM Blocksize  | Physical Reads  | Physical Writes
+64              | 64              | 6               | 6              
+256             | 64              | 8               | 8              
+64              | 4096            | 6               | 6              
+256             | 4096            | 8               | 8              
+
+Physical reads and writes incurred by 64 random VecPathOram operations:
+ORAM Capacity   | ORAM Blocksize  | Physical Reads  | Physical Writes
+64              | 64              | 384             | 384            
+256             | 64              | 512             | 512            
+64              | 4096            | 384             | 384            
+256             | 4096            | 512             | 512     
 ```

--- a/src/path_oram/generic_path_oram.rs
+++ b/src/path_oram/generic_path_oram.rs
@@ -9,7 +9,7 @@
 
 use super::{
     bucket::Bucket, position_map::PositionMap, stash::Stash, tree_index::CompleteBinaryTreeIndex,
-    PathOramBlock, TreeHeight, TreeIndex, MAXIMUM_TREE_HEIGHT,
+    PathOramBlock, TreeHeight, MAXIMUM_TREE_HEIGHT,
 };
 use crate::{
     database::{CountAccessesDatabase, Database},
@@ -56,18 +56,18 @@ impl<
         callback: F,
         rng: &mut R,
     ) -> Result<V, OramError> {
-        assert!(address < self.block_capacity());
+        assert!(address < self.block_capacity()?);
 
         // Get the position of the target block (with address `address`),
         // and update that block's position map entry to a fresh random position
-        let new_position = CompleteBinaryTreeIndex::random_leaf(self.height, rng);
+        let new_position = CompleteBinaryTreeIndex::random_leaf(self.height, rng)?;
         assert_ne!(new_position, 0);
         let position = self.position_map.write(address, new_position, rng)?;
         assert_ne!(position, 0);
         assert!(position.is_leaf(self.height));
 
         self.stash
-            .read_from_path(&mut self.physical_memory, position);
+            .read_from_path(&mut self.physical_memory, position)?;
 
         // Scan the stash for the target block, read its value into `result`,
         // and overwrite its position (and possibly its value).
@@ -76,12 +76,12 @@ impl<
         // Evict blocks from the stash into the path that was just read,
         // replacing them with dummy blocks.
         self.stash
-            .write_to_path(&mut self.physical_memory, position);
+            .write_to_path(&mut self.physical_memory, position)?;
 
-        Ok(result)
+        result
     }
 
-    fn new<R: Rng + CryptoRng>(block_capacity: usize, rng: &mut R) -> Result<Self, OramError> {
+    fn new<R: Rng + CryptoRng>(block_capacity: Address, rng: &mut R) -> Result<Self, OramError> {
         log::debug!(
             "Oram::new -- BlockOram(B = {}, Z = {}, C = {})",
             mem::size_of::<V>(),
@@ -94,31 +94,30 @@ impl<
 
         let number_of_nodes = block_capacity;
 
-        let height = block_capacity.ilog2() - 1;
+        let height: u64 = (block_capacity.ilog2() - 1).into();
         assert!(height <= MAXIMUM_TREE_HEIGHT);
 
-        let path_size = Z * (height as usize + 1);
-        let stash = S::new(path_size, 128 - path_size);
+        let path_size = u64::try_from(Z)? * (height + 1);
+        let stash = S::new(path_size, 128 - path_size)?;
 
         // physical_memory holds `block_capacity` buckets, each storing up to Z blocks.
         // The number of leaves is `block_capacity` / 2, which the original Path ORAM paper's experiments
         // found was sufficient to keep the stash size small with high probability.
         let mut physical_memory: CountAccessesDatabase<Bucket<V, Z>> =
-            Database::new(number_of_nodes);
+            Database::new(number_of_nodes)?;
 
         // The rest of this function initializes the logical memory to contain default values at every address.
         // This is done by (1) initializing the position map with fresh random leaf identifiers,
         // and (2) writing blocks to the physical memory with the appropriate positions, and default values.
-
         let mut position_map = P::new(block_capacity, rng)?;
 
         let slot_indices_to_addresses =
-            random_permutation_of_0_through_n_exclusive(block_capacity as u64, rng);
-        let addresses_to_slot_indices = invert_permutation_oblivious(&slot_indices_to_addresses);
-        let slot_indices_to_addresses = to_usize_vec(slot_indices_to_addresses);
-        let mut addresses_to_slot_indices = to_usize_vec(addresses_to_slot_indices);
+            random_permutation_of_0_through_n_exclusive(block_capacity, rng);
+        let addresses_to_slot_indices = invert_permutation_oblivious(&slot_indices_to_addresses)?;
+        let slot_indices_to_addresses = to_usize_vec(slot_indices_to_addresses)?;
+        let mut addresses_to_slot_indices = to_usize_vec(addresses_to_slot_indices)?;
 
-        let first_leaf_index = 2u64.pow(height) as usize;
+        let first_leaf_index: usize = 2u64.pow(height.try_into()?).try_into()?;
         let last_leaf_index = (2 * first_leaf_index) - 1;
 
         // Iterate over leaves, writing 2 blocks into each leaf bucket with random(ly permuted) addresses and default values.
@@ -129,31 +128,33 @@ impl<
                 let address_index = (leaf_index - first_leaf_index) * 2 + slot_index;
                 bucket_to_write.blocks[slot_index] = PathOramBlock::<V> {
                     value: V::default(),
-                    address: slot_indices_to_addresses[address_index],
-                    position: leaf_index as TreeIndex,
+                    address: slot_indices_to_addresses[address_index].try_into()?,
+                    position: leaf_index.try_into()?,
                 };
             }
 
             // Write the leaf bucket back to physical memory.
-            physical_memory.write_db(leaf_index, bucket_to_write);
+            physical_memory.write_db(leaf_index.try_into()?, bucket_to_write)?;
         }
 
         // The address block size might not divide the block capacity.
         // If it doesn't, we will have one block that contains dummy values.
-        let mut num_blocks = block_capacity / AB;
-        if block_capacity % AB > 0 {
+        let ab_address: Address = AB.try_into()?;
+        let mut num_blocks = block_capacity / ab_address;
+        if block_capacity % ab_address > 0 {
             num_blocks += 1;
-            addresses_to_slot_indices.resize(block_capacity + AB, 0);
+            addresses_to_slot_indices.resize((block_capacity + ab_address).try_into()?, 0);
         }
 
         for block_index in 0..num_blocks {
             let mut data = [0; AB];
             for i in 0..AB {
-                data[i] = (first_leaf_index + addresses_to_slot_indices[block_index * AB + i] / 2)
-                    as TreeIndex;
+                let offset: usize = (block_index * ab_address).try_into()?;
+                data[i] =
+                    (first_leaf_index + addresses_to_slot_indices[offset + i] / 2).try_into()?;
             }
             let block = AddressOramBlock::<AB> { data };
-            position_map.write_position_block(block_index * AB, block, rng)?;
+            position_map.write_position_block(block_index * ab_address, block, rng)?;
         }
 
         Ok(Self {
@@ -164,7 +165,7 @@ impl<
         })
     }
 
-    fn block_capacity(&self) -> Address {
+    fn block_capacity(&self) -> Result<Address, OramError> {
         self.physical_memory.capacity()
     }
 }

--- a/src/path_oram/mod.rs
+++ b/src/path_oram/mod.rs
@@ -11,7 +11,7 @@ use crate::BucketSize;
 use path_oram_block::PathOramBlock;
 
 pub(crate) type TreeIndex = u64;
-type TreeHeight = u32;
+type TreeHeight = u64;
 
 /// The parameter "Z" from the Path ORAM literature that sets the number of blocks per bucket; typical values are 3 or 4.
 /// Here we adopt the more conservative setting of 4.

--- a/src/path_oram/path_oram_block.rs
+++ b/src/path_oram/path_oram_block.rs
@@ -59,9 +59,8 @@ impl<V: OramBlock> OramBlock for PathOramBlock<V> {}
 impl<V: ConditionallySelectable> ConditionallySelectable for PathOramBlock<V> {
     fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
         let value = V::conditional_select(&a.value, &b.value, choice);
-        let address =
-            u64::conditional_select(&(a.address as u64), &(b.address as u64), choice) as usize;
-        let position = u64::conditional_select(&a.position, &b.position, choice);
+        let address = Address::conditional_select(&a.address, &b.address, choice);
+        let position = TreeIndex::conditional_select(&a.position, &b.position, choice);
         PathOramBlock::<V> {
             value,
             address,


### PR DESCRIPTION
Based on #29, #30, and #32.

Transitioned all numeric type aliases to u64s, with the exception of `BlockSize` and `BucketSize` which are used as const-generics array sizes. The point is consistency as well as platform-independent behavior.

In the process, I
- Removed all potentially panicking `as` numeric type conversions from non-test code, replacing them with fallible conversions returning `Result` values.
- Changed the return types of all functions that perform numeric type conversions, including `Database` methods and some `TreeIndex` methods, to `Result` values.
