### PR TITLE
Add documentation

### DIFF
--- a/src/block_value.rs
+++ b/src/block_value.rs
@@ -5,7 +5,7 @@
 // License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 // of this source tree. You may select, at your option, one of the above-listed licenses.
 
-//! Blocks
+//! Implements a generic ORAM value `BlockValue` consisting of unstructured bytes.
 
 use crate::BlockSize;
 use crate::OramBlock;
@@ -14,6 +14,10 @@ use rand::{
     Rng,
 };
 use subtle::{Choice, ConditionallySelectable};
+
+impl OramBlock for u8 {}
+impl OramBlock for u16 {}
+impl OramBlock for u32 {}
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[repr(align(64))]

--- a/src/database.rs
+++ b/src/database.rs
@@ -13,7 +13,7 @@ use crate::{Address, Oram, OramBlock, OramError};
 use duplicate::duplicate_item;
 use rand::{CryptoRng, RngCore};
 
-/// A simple Memory trait to model the memory controller the TEE is interacting with.
+/// Models a random-access memory.
 pub trait Database<V: OramBlock>
 where
     Self: Sized,
@@ -28,7 +28,7 @@ where
     fn write_db(&mut self, index: Address, value: V) -> Result<V, OramError>;
 }
 
-/// A simple Database that stores its data as a Vec.
+/// A simple `Database` that stores its data as a Vec.
 #[derive(Debug)]
 pub struct SimpleDatabase<V>(Vec<V>);
 
@@ -54,7 +54,7 @@ impl<V: OramBlock> Database<V> for SimpleDatabase<V> {
     }
 }
 
-/// A Database that counts reads and writes.
+/// A `Database` that counts reads and writes.
 #[derive(Debug)]
 pub struct CountAccessesDatabase<V> {
     data: SimpleDatabase<V>,
@@ -62,8 +62,6 @@ pub struct CountAccessesDatabase<V> {
     pub reads: Vec<u64>,
     /// `writes[i]` tracks the total number of writes made to index `i`.
     pub writes: Vec<u64>,
-    // read_count: u128,
-    // write_count: u128,
 }
 
 impl<V> CountAccessesDatabase<V> {

--- a/src/path_oram/address_oram_block.rs
+++ b/src/path_oram/address_oram_block.rs
@@ -5,8 +5,7 @@
 // License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 // of this source tree. You may select, at your option, one of the above-listed licenses.
 
-//! This module contains common test utilities for crates generating tests utilizing the
-//! `oram` crate.
+//! Implements `AddressOramBlock`, an ORAM block used in recursive position map ORAMs.
 
 use super::TreeIndex;
 use crate::{BlockSize, OramBlock};

--- a/src/path_oram/generic_recursive_path_oram.rs
+++ b/src/path_oram/generic_recursive_path_oram.rs
@@ -38,7 +38,7 @@ impl<
     }
 }
 
-/// An `Oram` intended for use as a position map. `AB` is the block size in addresses.
+/// An `Oram` intended for use as a position map. `AB` is the number of addresses stored in each ORAM block.
 #[derive(Debug)]
 pub enum AddressOram<
     const AB: BlockSize,

--- a/src/path_oram/mod.rs
+++ b/src/path_oram/mod.rs
@@ -17,14 +17,16 @@ type TreeHeight = u64;
 /// Here we adopt the more conservative setting of 4.
 pub const DEFAULT_BLOCKS_PER_BUCKET: BucketSize = 4;
 
+pub use stash::Stash;
+
 pub(crate) mod address_oram_block;
 pub(crate) mod bitonic_sort;
 pub(crate) mod bucket;
-pub mod generic_path_oram;
-pub mod generic_recursive_path_oram;
+pub(crate) mod generic_path_oram;
+pub(crate) mod generic_recursive_path_oram;
 pub(crate) mod oblivious_stash;
 mod path_oram_block;
 pub(crate) mod position_map;
 pub mod recursive_secure_path_oram;
-pub(crate) mod stash;
+mod stash;
 mod tree_index;

--- a/src/path_oram/oblivious_stash.rs
+++ b/src/path_oram/oblivious_stash.rs
@@ -5,7 +5,7 @@
 // License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 // of this source tree. You may select, at your option, one of the above-listed licenses.
 
-//! A fixed-size, obliviously accessed stash implemented using oblivious sorting.
+//! Contains `BitonicStash`, a fixed-size, obliviously accessed Path ORAM stash data structure implemented using oblivious sorting.
 
 use super::{
     bucket::Bucket,
@@ -21,7 +21,7 @@ use crate::{
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
 #[derive(Debug)]
-/// A fixed-size, obliviously accessed stash data structure implemented using oblivious sorting.
+/// A fixed-size, obliviously accessed Path ORAM stash data structure implemented using oblivious sorting.
 pub struct BitonicStash<V: OramBlock> {
     blocks: Vec<PathOramBlock<V>>,
     path_size: StashSize,

--- a/src/path_oram/path_oram_block.rs
+++ b/src/path_oram/path_oram_block.rs
@@ -5,7 +5,7 @@
 // License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 // of this source tree. You may select, at your option, one of the above-listed licenses.
 
-//! A Path ORAM block.
+//! Implements a Path ORAM block `PathOramBlock<V>`.
 
 use crate::{path_oram::TreeIndex, Address, OramBlock};
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
@@ -13,6 +13,7 @@ use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 impl OramBlock for TreeIndex {}
 
 #[derive(Clone, Copy, Default, PartialEq)]
+/// A Path ORAM block combines an `OramBlock` V with two metadata fields; its ORAM `address` and its `position` in the tree.
 pub struct PathOramBlock<V> {
     pub value: V,
     pub address: Address,

--- a/src/path_oram/position_map.rs
+++ b/src/path_oram/position_map.rs
@@ -5,7 +5,7 @@
 // License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 // of this source tree. You may select, at your option, one of the above-listed licenses.
 
-//! A trait representing a Path ORAM position map.
+//! Implements a trait `PositionMap` representing a Path ORAM position map data structure.
 
 use rand::{CryptoRng, RngCore};
 

--- a/src/path_oram/recursive_secure_path_oram.rs
+++ b/src/path_oram/recursive_secure_path_oram.rs
@@ -29,6 +29,17 @@ pub type ConcreteObliviousAddressOram<const AB: BlockSize, V> = GenericPathOram<
 pub type ConcreteObliviousBlockOram<const B: BlockSize, V> =
     BlockOram<B, V, DEFAULT_BLOCKS_PER_BUCKET, BitonicStash<AddressOramBlock<B>>, BitonicStash<V>>;
 
+const DEFAULT_BLOCK_SIZE: BlockSize = 64;
+const DEFAULT_ADDRESS_BLOCK_SIZE: BlockSize = 64;
+/// An even simpler Path ORAM type with address block size fixed.
+pub type DefaultPathOram<V> = BlockOram<
+    DEFAULT_BLOCK_SIZE,
+    V,
+    DEFAULT_BLOCKS_PER_BUCKET,
+    BitonicStash<AddressOramBlock<DEFAULT_ADDRESS_BLOCK_SIZE>>,
+    BitonicStash<V>,
+>;
+
 #[cfg(test)]
 mod address_oram_tests {
     use super::*;

--- a/src/path_oram/stash.rs
+++ b/src/path_oram/stash.rs
@@ -5,7 +5,7 @@
 // License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 // of this source tree. You may select, at your option, one of the above-listed licenses.
 
-//! A trait representing a Path ORAM stash.
+//! Implements a trait `Stash` representing a Path ORAM stash data structure.
 
 use super::{bucket::Bucket, TreeIndex};
 use crate::{database::Database, Address, BucketSize, OramBlock, OramError};
@@ -13,26 +13,29 @@ use crate::{database::Database, Address, BucketSize, OramBlock, OramError};
 /// Numeric type used to represent the size of a Path ORAM stash in blocks.
 pub type StashSize = u64;
 
-/// A Path ORAM stash.
+/// A generic Path ORAM stash data structure.
 pub trait Stash<V: OramBlock>
 where
     Self: Sized,
 {
     /// Creates a new stash capable of holding `capacity` blocks.
     fn new(path_size: StashSize, overflow_size: StashSize) -> Result<Self, OramError>;
-    /// Read blocks from the path specified by the leaf `position` in the tree `physical_memory` of height `height`
+
+    /// Reads blocks from the path specified by the leaf `position` in the tree `physical_memory` of height `height`.
     fn read_from_path<const Z: BucketSize, T: Database<Bucket<V, Z>>>(
         &mut self,
         physical_memory: &mut T,
         position: TreeIndex,
     ) -> Result<(), OramError>;
-    /// Evict blocks from the stash to the path specified by the leaf `position` in the tree `physical_memory` of height `height`.
+
+    /// Evicts blocks from the stash to the path specified by the leaf `position` in the tree `physical_memory` of height `height`.
     fn write_to_path<const Z: BucketSize, T: Database<Bucket<V, Z>>>(
         &mut self,
         physical_memory: &mut T,
         position: TreeIndex,
     ) -> Result<(), OramError>;
-    /// Obliviously scans the stash for a block `b` with address `address`; if found, replaces that block with `callback(b)`.
+
+    /// Obliviously scans the stash for a block `b` with address `address`; if found, replaces that block with `callback(b)` and returns `b`.
     fn access<F: Fn(&V) -> V>(
         &mut self,
         address: Address,

--- a/src/path_oram/tree_index.rs
+++ b/src/path_oram/tree_index.rs
@@ -5,7 +5,7 @@
 // License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 // of this source tree. You may select, at your option, one of the above-listed licenses.
 
-//! Tree index
+//! Utilities for working with indices into a Path ORAM tree data structure.
 
 use super::{TreeHeight, TreeIndex};
 use rand::{CryptoRng, Rng, RngCore};
@@ -14,7 +14,7 @@ use std::{mem::size_of, num::TryFromIntError};
 
 const_assert_eq!(size_of::<TreeIndex>(), 8);
 
-pub trait CompleteBinaryTreeIndex
+pub(crate) trait CompleteBinaryTreeIndex
 where
     Self: Sized,
 {

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -16,7 +16,7 @@ use crate::linear_time_oram::LinearTimeOram;
 use crate::path_oram::bucket::Bucket;
 use crate::path_oram::generic_path_oram::GenericPathOram;
 use crate::path_oram::position_map::PositionMap;
-use crate::path_oram::stash::Stash;
+use crate::path_oram::Stash;
 use crate::{Address, BlockSize, BucketSize, Oram, OramBlock, OramError};
 use duplicate::duplicate_item;
 use rand::{

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -12,6 +12,7 @@ use crate::OramError;
 use rand::seq::SliceRandom;
 use rand::{CryptoRng, RngCore};
 
+/// Returns a random permutation of 0 through n.
 pub(crate) fn random_permutation_of_0_through_n_exclusive<R: RngCore + CryptoRng>(
     n: u64,
     rng: &mut R,
@@ -23,6 +24,7 @@ pub(crate) fn random_permutation_of_0_through_n_exclusive<R: RngCore + CryptoRng
     Vec::from(permuted_addresses)
 }
 
+/// Given a permutation, inverts it using oblivious (data-independent) operations.
 pub(crate) fn invert_permutation_oblivious(permutation: &[u64]) -> Result<Vec<u64>, OramError> {
     let n: u64 = permutation.len().try_into()?;
     let mut copied = permutation.to_owned();
@@ -31,6 +33,7 @@ pub(crate) fn invert_permutation_oblivious(permutation: &[u64]) -> Result<Vec<u6
     Ok(result)
 }
 
+/// Converts a `Vec<u64>` to a `Vec<usize>`.
 pub(crate) fn to_usize_vec(source: Vec<u64>) -> Result<Vec<usize>, OramError> {
     let mut result = Vec::new();
     for e in &source {


### PR DESCRIPTION
Added and updated documentation comments throughout. 

In the process, I wrote down a number of TODOs which I wanted to flag, in no particular order.  (I'm deferring them now in the interest of keeping this PR small.)

- In the crate page, include a more nuanced discussion about obliviousness that emphasizes that `oram` does not handle encryption-on-write and decryption-on-read.
- Decouple block size and address ORAM block size in `GenericPathOram`.
- Split `BlockSize` into two type aliases; one for `BlockValue` sizes and one for `AddressOramBlock` block sizes. Since the first is measured in bytes and the second is measured in addresses, keeping type aliases separate is more accurate.
- Add more context to `OramError` variants.
- Add a Rust MSRV.
- Rename `BlockOram`, `AddressOram`, and their specializations. The names need to be more evocative.
- Add an example using `BlockValue` to instantiate an ORAM with large (4096B) blocks. 
- Also, add `BlockValue` specializations to 64 byte and 4096 byte blocks with appropriate alignment.
- Consider workarounds to public fields in `LinearTimeOram` and `GenericPathOram`, which are currently needed for testing and benchmarking.
- Make the stash size parameter easily configurable.
