### PR TITLE
Resizable stash

### DIFF
--- a/src/path_oram/generic_path_oram.rs
+++ b/src/path_oram/generic_path_oram.rs
@@ -7,7 +7,11 @@
 
 //! Contains an abstract implementation of Path ORAM that is generic over its stash and position map data structures.
 
-use super::{position_map::PositionMap, stash::Stash, Bucket, PathOramBlock};
+use super::{
+    position_map::PositionMap,
+    stash::{Stash, StashSize},
+    Bucket, PathOramBlock,
+};
 use crate::{
     database::{CountAccessesDatabase, Database},
     path_oram::AddressOramBlock,
@@ -19,6 +23,8 @@ use crate::{
 };
 use rand::{CryptoRng, Rng};
 use std::mem;
+
+const STASH_SIZE: StashSize = 128;
 
 /// A Path ORAM which is generic over its stash and position map data structures.
 #[derive(Debug)]
@@ -98,7 +104,7 @@ impl<
         let height: u64 = (block_capacity.ilog2() - 1).into();
 
         let path_size = u64::try_from(Z)? * (height + 1);
-        let stash = S::new(path_size, 128 - path_size)?;
+        let stash = S::new(path_size, STASH_SIZE - path_size)?;
 
         // physical_memory holds `block_capacity` buckets, each storing up to Z blocks.
         // The number of leaves is `block_capacity` / 2, which the original Path ORAM paper's experiments

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -154,7 +154,7 @@ macro_rules! create_correctness_tests_for_workload_and_oram_type {
         create_correctness_test_block_value!($function_name, $oram_type, $block_type, 8, 8, 100);
         create_correctness_test_block_value!($function_name, $oram_type, $block_type, 4, 16, 100);
         create_correctness_test_block_value!($function_name, $oram_type, $block_type, 4, 32, 100);
-        // Block size 16 bytes, block capacity 32 blocks, testing with 100 operations
+        // Block size 16 bytes, block capacity 64 blocks, testing with 100 operations
         create_correctness_test_block_value!($function_name, $oram_type, $block_type, 16, 64, 100);
         create_correctness_test_block_value!($function_name, $oram_type, $block_type, 2, 8, 1000);
     };


### PR DESCRIPTION
Based on #39 and #40. Added logic so that the stash resizes itself in case of overflow. This prevents ORAM failure in case the stash is initially sized too small. However, stash resizing is technically a breach of obliviousness; it is preferable to size the stash large enough that resizing never occurs.

Currently, the stash size is hardcoded to 128 and doubles in case of overflow. In the next PR I will
- remove the restriction that the stash size must be a power of two,
- apply a heuristic to set it so that the probability of overflow is small (say 2^{-50}).
Experiments done in the [original Path ORAM paper](https://eprint.iacr.org/2013/280.pdf) imply that less than 40 overflow blocks suffice.