### PR TITLE
Added support for arbitrary stash sizes.

### DIFF
--- a/examples/interactive.rs
+++ b/examples/interactive.rs
@@ -42,9 +42,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut rl = Editor::<(), _>::new().unwrap();
 
     println!("In this example, we initialize and interact with an oblivious RAM storing u64s.");
-    println!("How many u64s would you like the ORAM to store?");
 
-    let capacity = parse_u64("Enter a power of two.", &mut rl)?;
+    let capacity = parse_u64("How many u64s would you like the ORAM to store?", &mut rl)?;
 
     // Initialize a Path ORAM storing `capacity` u64s.
     let mut oram =

--- a/src/path_oram/generic_path_oram.rs
+++ b/src/path_oram/generic_path_oram.rs
@@ -24,7 +24,7 @@ use crate::{
 use rand::{CryptoRng, Rng};
 use std::mem;
 
-const STASH_SIZE: StashSize = 128;
+const OVERFLOW_SIZE: StashSize = 40;
 
 /// A Path ORAM which is generic over its stash and position map data structures.
 #[derive(Debug)]
@@ -104,7 +104,7 @@ impl<
         let height: u64 = (block_capacity.ilog2() - 1).into();
 
         let path_size = u64::try_from(Z)? * (height + 1);
-        let stash = S::new(path_size, STASH_SIZE - path_size)?;
+        let stash = S::new(path_size, OVERFLOW_SIZE)?;
 
         // physical_memory holds `block_capacity` buckets, each storing up to Z blocks.
         // The number of leaves is `block_capacity` / 2, which the original Path ORAM paper's experiments

--- a/src/path_oram/stash.rs
+++ b/src/path_oram/stash.rs
@@ -67,9 +67,6 @@ impl<V: OramBlock> BitonicStash<V> {
 impl<V: OramBlock> Stash<V> for BitonicStash<V> {
     fn new(path_size: StashSize, overflow_size: StashSize) -> Result<Self, OramError> {
         let num_stash_blocks: usize = (path_size + overflow_size).try_into()?;
-        if !(num_stash_blocks.is_power_of_two()) {
-            return Err(OramError::InvalidConfigurationError);
-        }
 
         Ok(Self {
             blocks: vec![PathOramBlock::<V>::dummy(); num_stash_blocks],


### PR DESCRIPTION
Based on #39, #40 and #41. 

- Added support for arbitrary stash sizes by implementing bitonic sort for arbitrary array sizes.
- Set the stash overflow size to 40 blocks. According to experiments done in the [original Path ORAM paper](https://eprint.iacr.org/2013/280.pdf), this should lower the probability of stash overflow on any given access below 2^{-50}.