### PR TITLE
Provided default and configurable ORAM types

### DIFF
--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -17,13 +17,12 @@ use oram::database::CountAccessesDatabase;
 use std::fmt::Display;
 use std::time::Duration;
 
-use oram::bucket::{BlockValue, DEFAULT_BLOCKS_PER_BUCKET};
+use oram::bucket::BlockValue;
 use oram::BlockSize;
-use oram::{Address, Oram};
+use oram::{Address, DefaultOram, Oram};
 use rand::{rngs::StdRng, Rng, SeedableRng};
 
 use oram::linear_time_oram::LinearTimeOram;
-use oram::path_oram::PathOram;
 
 const CAPACITIES_TO_BENCHMARK: [Address; 3] = [1 << 14, 1 << 16, 1 << 20];
 const NUM_RANDOM_OPERATIONS_TO_RUN: u64 = 64;
@@ -37,8 +36,7 @@ trait Instrumented {
 type BenchmarkLinearTimeOram<const B: BlockSize> =
     LinearTimeOram<CountAccessesDatabase<BlockValue<B>>>;
 
-type BenchmarkRecursiveSecurePathOram<const B: BlockSize> =
-    PathOram<BlockValue<B>, DEFAULT_BLOCKS_PER_BUCKET, 4096>;
+type BenchmarkRecursiveSecurePathOram<const B: BlockSize> = DefaultOram<BlockValue<B>>;
 
 impl<const B: BlockSize> Instrumented for BenchmarkRecursiveSecurePathOram<B> {
     fn get_read_count(&self) -> u64 {

--- a/examples/interactive.rs
+++ b/examples/interactive.rs
@@ -7,16 +7,10 @@
 
 //! A simple interactive demonstration of ORAM.
 
-use oram::bucket::DEFAULT_BLOCKS_PER_BUCKET;
-use oram::path_oram::PathOram;
-use oram::{BlockSize, Oram};
+use oram::{DefaultOram, Oram};
 use rand::rngs::OsRng;
 use rustyline::history::FileHistory;
 use rustyline::Editor;
-
-// The number of positions stored in each block used by the ORAM's recursive position map.
-const ADDRESS_BLOCK_SIZE: BlockSize = 64;
-type OramValue = u64;
 
 fn parse_u64(
     prompt: &str,
@@ -43,13 +37,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut rl = Editor::<(), _>::new().unwrap();
 
     println!("In this example, we initialize and interact with an oblivious RAM storing u64s.");
+    println!("How many u64s would you like the ORAM to store?");
 
-    let capacity = parse_u64("How many u64s would you like the ORAM to store?", &mut rl)?;
+    let capacity = parse_u64("Enter a power of two:", &mut rl)?;
 
     // Initialize a Path ORAM storing `capacity` u64s.
-    let mut oram = PathOram::<OramValue, DEFAULT_BLOCKS_PER_BUCKET, ADDRESS_BLOCK_SIZE>::new(
-        capacity, &mut rng,
-    )?;
+    let mut oram = DefaultOram::<u64>::new(capacity, &mut rng)?;
 
     loop {
         let action = loop {

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -20,10 +20,6 @@ use crate::BucketSize;
 use crate::{utils::TreeIndex, Address};
 use subtle::ConstantTimeEq;
 
-/// The parameter "Z" from the Path ORAM literature that sets the number of blocks per bucket; typical values are 3 or 4.
-/// Here we adopt the more conservative setting of 4.
-pub const DEFAULT_BLOCKS_PER_BUCKET: BucketSize = 4;
-
 // REVIEW NOTE: the rest of this module is not new code. It was moved from lib.rs and path_oram/mod.rs.
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[repr(align(64))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,12 +30,12 @@
 //!
 //! ```
 //! use rand::rngs::OsRng;
-//! use oram::{Oram, PathOram, bucket::DEFAULT_BLOCKS_PER_BUCKET};
+//! use oram::{Oram, DefaultOram};
 //! # use oram::OramError;
 //!
 //! let capacity = 64;
 //! let mut rng = OsRng;
-//! let mut oram = PathOram::<u8, DEFAULT_BLOCKS_PER_BUCKET, 64>::new(capacity, &mut rng)?;
+//! let mut oram = DefaultOram::<u8>::new(capacity, &mut rng)?;
 //! oram.write(1, 42u8, &mut rng)?;
 //! assert_eq!(oram.read(1, &mut rng)?, 42u8);
 //! # Ok::<(), OramError>(())
@@ -59,6 +59,7 @@ pub(crate) mod stash;
 mod test_utils;
 pub(crate) mod utils;
 
+pub use crate::path_oram::DefaultOram;
 pub use crate::path_oram::PathOram;
 
 /// The numeric type used to specify the size of an ORAM block in bytes.

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -14,7 +14,8 @@ static INIT: Once = Once::new();
 use crate::bucket::Bucket;
 use crate::database::{CountAccessesDatabase, Database, SimpleDatabase};
 use crate::linear_time_oram::LinearTimeOram;
-use crate::path_oram::PathOram;
+use crate::path_oram::DEFAULT_RECURSION_THRESHOLD;
+use crate::path_oram::{PathOram, RecursionThreshold};
 use crate::{Address, BlockSize, BucketSize, Oram, OramBlock, OramError};
 use duplicate::duplicate_item;
 use rand::{
@@ -42,7 +43,10 @@ pub trait Testable {
 )]
 impl<V: OramBlock> Testable for database_type<V> {}
 impl<DB> Testable for LinearTimeOram<DB> {}
-impl<V: OramBlock, const Z: BucketSize, const AB: BlockSize> Testable for PathOram<V, Z, AB> {}
+impl<V: OramBlock, const Z: BucketSize, const AB: BlockSize, const RT: RecursionThreshold> Testable
+    for PathOram<V, Z, AB, RT>
+{
+}
 
 /// Tests the correctness of an `ORAM` implementation T on a workload of random reads and writes.
 pub(crate) fn test_correctness_random_workload<V: OramBlock, T: Oram<V> + Testable>(
@@ -216,7 +220,7 @@ pub(crate) struct StashSizeMonitor<T> {
 impl<T> Testable for StashSizeMonitor<T> {}
 
 pub(crate) type VecStashSizeMonitor<V, const Z: BucketSize, const AB: BlockSize> =
-    StashSizeMonitor<PathOram<V, Z, AB>>;
+    StashSizeMonitor<PathOram<V, Z, AB, DEFAULT_RECURSION_THRESHOLD>>;
 
 impl<V: OramBlock, const Z: BucketSize, const AB: BlockSize> Oram<V>
     for VecStashSizeMonitor<V, Z, AB>
@@ -244,7 +248,7 @@ pub(crate) struct ConstantOccupancyMonitor<T> {
 impl<T> Testable for ConstantOccupancyMonitor<T> {}
 
 pub(crate) type VecConstantOccupancyMonitor<V, const Z: BucketSize, const AB: BlockSize> =
-    ConstantOccupancyMonitor<PathOram<V, Z, AB>>;
+    ConstantOccupancyMonitor<PathOram<V, Z, AB, DEFAULT_RECURSION_THRESHOLD>>;
 
 impl<V: OramBlock, const Z: BucketSize, const AB: BlockSize> Oram<V>
     for VecConstantOccupancyMonitor<V, Z, AB>
@@ -278,7 +282,7 @@ pub(crate) struct PhysicalAccessCountMonitor<T> {
 impl<T> Testable for PhysicalAccessCountMonitor<T> {}
 
 pub(crate) type VecPhysicalAccessCountMonitor<V, const Z: BucketSize, const AB: BlockSize> =
-    PhysicalAccessCountMonitor<PathOram<V, Z, AB>>;
+    PhysicalAccessCountMonitor<PathOram<V, Z, AB, DEFAULT_RECURSION_THRESHOLD>>;
 
 impl<V: OramBlock, const Z: BucketSize, const AB: BlockSize> Oram<V>
     for VecPhysicalAccessCountMonitor<V, Z, AB>


### PR DESCRIPTION
Based on #43. Refactored the library API to expose two ORAM types to users: a default type `DefaultOram` and a configurable type `PathOram` which gives the user control over the bucket size, position block size, and recursion cutoff.
