### PR TITLE
Improved documentation

### DIFF
--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -13,16 +13,13 @@
 extern crate criterion;
 use core::fmt;
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
-use oram::database::CountAccessesDatabase;
 use std::fmt::Display;
 use std::time::Duration;
 
-use oram::bucket::BlockValue;
 use oram::BlockSize;
+use oram::BlockValue;
 use oram::{Address, DefaultOram, Oram};
 use rand::{rngs::StdRng, Rng, SeedableRng};
-
-use oram::linear_time_oram::LinearTimeOram;
 
 const CAPACITIES_TO_BENCHMARK: [Address; 3] = [1 << 14, 1 << 16, 1 << 20];
 const NUM_RANDOM_OPERATIONS_TO_RUN: u64 = 64;
@@ -32,9 +29,6 @@ trait Instrumented {
     fn get_write_count(&self) -> u64;
     fn short_name() -> String;
 }
-
-type BenchmarkLinearTimeOram<const B: BlockSize> =
-    LinearTimeOram<CountAccessesDatabase<BlockValue<B>>>;
 
 type BenchmarkRecursiveSecurePathOram<const B: BlockSize> = DefaultOram<BlockValue<B>>;
 
@@ -52,31 +46,13 @@ impl<const B: BlockSize> Instrumented for BenchmarkRecursiveSecurePathOram<B> {
     }
 }
 
-impl<const B: BlockSize> Instrumented for BenchmarkLinearTimeOram<B> {
-    fn get_read_count(&self) -> u64 {
-        return self.physical_memory.get_read_count();
-    }
-
-    fn get_write_count(&self) -> u64 {
-        return self.physical_memory.get_write_count();
-    }
-
-    fn short_name() -> String {
-        "LinearTimeOram".into()
-    }
-}
-
 // Here, all benchmarks are run for linear and path ORAMs, and block sizes of 64 and 4096.
 criterion_group!(
     name = benches;
     config = Criterion::default().warm_up_time(Duration::new(0, 1_000_000_00)).measurement_time(Duration::new(0, 1_000_000_00)).sample_size(10);
     targets =
-    benchmark_read::<4096, BenchmarkLinearTimeOram<4096>>,
     benchmark_read::<4096, BenchmarkRecursiveSecurePathOram<4096>>,
-    benchmark_initialization::<4096, BenchmarkLinearTimeOram<4096>>,
     benchmark_initialization::<4096, BenchmarkRecursiveSecurePathOram<4096>>,
-    print_read_header::<BenchmarkLinearTimeOram<0>>,
-    count_accesses_on_read::<4096, BenchmarkLinearTimeOram<4096>>,
     print_read_header::<BenchmarkRecursiveSecurePathOram<0>>,
     count_accesses_on_read::<4096, BenchmarkRecursiveSecurePathOram<4096>>,
 );
@@ -85,15 +61,6 @@ criterion_group!(
 //     name = benches;
 //     config = Criterion::default().warm_up_time(Duration::new(0, 1_000_000_00)).measurement_time(Duration::new(0, 1_000_000_00)).sample_size(10);
 //     targets =
-//     benchmark_read::<4096, BenchmarkRecursiveSecurePathOram<4096>>,
-//     benchmark_initialization::<64, BenchmarkLinearTimeOram<64>>,
-//     benchmark_initialization::<4096, BenchmarkLinearTimeOram<4096>>,
-//     benchmark_read::<64, BenchmarkLinearTimeOram<64>>,
-//     benchmark_read::<4096, BenchmarkLinearTimeOram<4096>>,
-//     benchmark_write::<64, BenchmarkLinearTimeOram<64>>,
-//     benchmark_write::<4096, BenchmarkLinearTimeOram<4096>>,
-//     benchmark_random_operations::<64, BenchmarkLinearTimeOram<64>>,
-//     benchmark_random_operations::<4096, BenchmarkLinearTimeOram<4096>>,
 //     benchmark_initialization::<64, BenchmarkRecursiveSecurePathOram<64>>,
 //     benchmark_initialization::<4096, BenchmarkRecursiveSecurePathOram<4096>>,
 //     benchmark_read::<64, BenchmarkRecursiveSecurePathOram<64>>,
@@ -102,15 +69,6 @@ criterion_group!(
 //     benchmark_write::<4096, BenchmarkRecursiveSecurePathOram<4096>>,
 //     benchmark_random_operations::<64, BenchmarkRecursiveSecurePathOram<64>>,
 //     benchmark_random_operations::<4096, BenchmarkRecursiveSecurePathOram<4096>>,
-//     print_read_header::<BenchmarkLinearTimeOram<0>>,
-//     count_accesses_on_read::<64, BenchmarkLinearTimeOram<64>>,
-//     count_accesses_on_read::<4096, BenchmarkLinearTimeOram<4096>>,
-//     print_write_header::<BenchmarkLinearTimeOram<0>>,
-//     count_accesses_on_write::<64, BenchmarkLinearTimeOram<64>>,
-//     count_accesses_on_write::<4096, BenchmarkLinearTimeOram<4096>>,
-//     print_random_operations_header::<BenchmarkLinearTimeOram<0>>,
-//     count_accesses_on_random_workload::<64, BenchmarkLinearTimeOram<64>>,
-//     count_accesses_on_random_workload::<4096, BenchmarkLinearTimeOram<4096>>,
 //     print_read_header::<BenchmarkRecursiveSecurePathOram<0>>,
 //     count_accesses_on_read::<64, BenchmarkRecursiveSecurePathOram<64>>,
 //     count_accesses_on_read::<4096, BenchmarkRecursiveSecurePathOram<4096>>,

--- a/examples/oblivious_db.rs
+++ b/examples/oblivious_db.rs
@@ -1,0 +1,39 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is dual-licensed under either the MIT license found in the
+// LICENSE-MIT file in the root directory of this source tree or the Apache
+// License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+// of this source tree. You may select, at your option, one of the above-listed licenses.
+
+//! An example of using ORAM to obliviously serve an indexed database.
+
+extern crate oram;
+
+use oram::{Address, BlockSize, BlockValue, DefaultOram, Oram, OramError};
+use rand::{rngs::OsRng, Rng};
+
+const BLOCK_SIZE: BlockSize = 4096;
+const DB_SIZE: Address = 64;
+// A stand-in for the indexed database you want to obliviously serve.
+const DATABASE: [[u8; BLOCK_SIZE as usize]; DB_SIZE as usize] =
+    [[0; BLOCK_SIZE as usize]; DB_SIZE as usize];
+
+fn main() -> Result<(), OramError> {
+    let mut rng = OsRng;
+    let mut oram = DefaultOram::<BlockValue<4096>>::new(DB_SIZE, &mut rng)?;
+
+    // Read DATABASE into oram.
+    for (i, bytes) in DATABASE.iter().enumerate() {
+        oram.write(i as Address, BlockValue::new(*bytes), &mut rng)?;
+    }
+
+    // Now oram can be used to obliviously serve the contents of DATABASE.
+    let num_operations = 100;
+    for _ in 0..num_operations {
+        let random_index = rng.gen_range(0..DB_SIZE);
+
+        let _ = oram.read(random_index, &mut rng)?;
+    }
+
+    Ok(())
+}

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -20,7 +20,6 @@ use crate::BucketSize;
 use crate::{utils::TreeIndex, Address};
 use subtle::ConstantTimeEq;
 
-// REVIEW NOTE: the rest of this module is not new code. It was moved from lib.rs and path_oram/mod.rs.
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[repr(align(64))]
 /// An `OramBlock` consisting of unstructured bytes.

--- a/src/path_oram.rs
+++ b/src/path_oram.rs
@@ -200,7 +200,6 @@ pub type ConcreteObliviousBlockOram<const B: BlockSize, V> =
 pub type ConcreteObliviousAddressOram<const AB: BlockSize, V> =
     PathOram<V, DEFAULT_BLOCKS_PER_BUCKET, AB, DEFAULT_RECURSION_THRESHOLD>;
 
-// REVIEW NOTE: the below test modules are not new code.
 #[cfg(test)]
 mod block_oram_tests {
     use bucket::BlockValue;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,7 +7,7 @@
 
 //! Utilities.
 
-use crate::{OramBlock, OramError};
+use crate::OramError;
 use rand::seq::SliceRandom;
 use rand::{CryptoRng, Rng, RngCore};
 
@@ -18,8 +18,6 @@ use std::{mem::size_of, num::TryFromIntError};
 
 pub(crate) type TreeIndex = u64;
 pub(crate) type TreeHeight = u64;
-
-impl OramBlock for TreeIndex {}
 
 const_assert_eq!(size_of::<TreeIndex>(), 8);
 


### PR DESCRIPTION
Based on #43 and #44. 
Code:
- Made modules `bucket`, `database`, and `linear_time_oram` private.
- Removed `LinearTimeOram` benchmarks (since `LinearTimeOram` isn't part of the public `oram` API).

Documentation:
- Rewrote the crate overview to specialize it to the enclave setting.
- Added a reference to the Oblix paper on which the oblivious stash is based.
- Made the example in the crate overview slightly more realistic. I also added it to examples/.

Minor
- Added implementations of `OramBlock` for all explicitly sized numeric primitives.

Up next: finish "Advanced" section and expose the stash overflow size as a parameter.