### PR TITLE
Added description of parameters

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@
 //!
 //! # Example
 //!
-//! The below example reads a database from memory into an ORAM to permit secret-dependent access to it.
+//! The below example reads a database from memory into an ORAM, thus permitting secret-dependent accesses.
 //!
 //! ```
 //! use oram::{Address, BlockSize, BlockValue, Oram, DefaultOram};
@@ -35,10 +35,10 @@
 //! # [[0; BLOCK_SIZE as usize]; DB_SIZE as usize];
 //! let mut rng = rand::rngs::OsRng;
 //!
-//! // Initialize `oram` to store 64 blocks of 64 bytes each.
+//! // Initialize an ORAM to store 64 blocks of 64 bytes each.
 //! let mut oram = DefaultOram::<BlockValue<BLOCK_SIZE>>::new(DB_SIZE, &mut rng)?;
 //!
-//! // Read DATABASE into oram.
+//! // Read a database (here, an array of byte arrays) into the ORAM.
 //! for (i, bytes) in DATABASE.iter().enumerate() {
 //!     oram.write(i as Address, BlockValue::new(*bytes), &mut rng)?;
 //! }
@@ -57,7 +57,35 @@
 //!
 //! The `DefaultOram` used in the above example should have good performance in most use cases.
 //! But the underlying algorithms have several tunable parameters that impact performance.
-//! TO BE CONTINUED
+//! The following example instantiates the same ORAM struct as above, but using the `PathOram`
+//! interface which exposes these parameters.
+//!
+//! ```
+//! use oram::{Address, BlockSize, BlockValue, BucketSize,
+//!             Oram, PathOram, StashSize, RecursionCutoff};
+//! use oram::path_oram::{DEFAULT_BLOCKS_PER_BUCKET, DEFAULT_RECURSION_CUTOFF,
+//!             DEFAULT_POSITIONS_PER_BLOCK, DEFAULT_STASH_OVERFLOW_SIZE};
+//! # use oram::OramError;
+//! # let mut rng = rand::rngs::OsRng;
+//! # const BLOCK_SIZE: BlockSize = 64;
+//! # const DB_SIZE: Address = 64;
+//!
+//! const RECURSION_CUTOFF: RecursionCutoff = DEFAULT_RECURSION_CUTOFF;
+//! const BUCKET_SIZE: BucketSize = DEFAULT_BLOCKS_PER_BUCKET;
+//! const POSITIONS_PER_BLOCK: BlockSize = DEFAULT_POSITIONS_PER_BLOCK;
+//! const INITIAL_STASH_OVERFLOW_SIZE: StashSize = DEFAULT_STASH_OVERFLOW_SIZE;
+//!
+//! let mut oram = PathOram::<
+//!     BlockValue<BLOCK_SIZE>,
+//!     BUCKET_SIZE,
+//!     POSITIONS_PER_BLOCK,
+//!     RECURSION_CUTOFF,
+//!     INITIAL_STASH_OVERFLOW_SIZE
+//!     >::new(DB_SIZE, &mut rng)?;
+//! # Ok::<(), OramError>(())
+//! ```
+//!
+//! See [`PathOram`] for an explanation of these parameters and their possible settings.
 
 #![warn(clippy::cargo, clippy::doc_markdown, missing_docs, rustdoc::all)]
 
@@ -87,6 +115,11 @@ pub type BlockSize = usize;
 pub type Address = u64;
 /// The numeric type used to specify the size of an ORAM bucket in blocks.
 pub type BucketSize = usize;
+/// The numeric type used to specify the cutoff size
+/// below which `PathOram` uses a linear position map instead of a recursive one.
+pub type RecursionCutoff = u64;
+/// Numeric type used to represent the size of a Path ORAM stash in blocks.
+pub type StashSize = u64;
 
 /// A "trait alias" for ORAM blocks: the values read and written by ORAMs.
 pub trait OramBlock:

--- a/src/stash.rs
+++ b/src/stash.rs
@@ -11,11 +11,8 @@ use crate::{
     bucket::{Bucket, PathOramBlock},
     database::Database,
     utils::{bitonic_sort_by_keys, CompleteBinaryTreeIndex, TreeIndex},
-    Address, BucketSize, OramBlock, OramError,
+    Address, BucketSize, OramBlock, OramError, StashSize,
 };
-
-/// Numeric type used to represent the size of a Path ORAM stash in blocks.
-pub type StashSize = u64;
 
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -14,9 +14,10 @@ static INIT: Once = Once::new();
 use crate::bucket::Bucket;
 use crate::database::{CountAccessesDatabase, Database, SimpleDatabase};
 use crate::linear_time_oram::LinearTimeOram;
-use crate::path_oram::DEFAULT_RECURSION_THRESHOLD;
-use crate::path_oram::{PathOram, RecursionThreshold};
-use crate::{Address, BlockSize, BucketSize, Oram, OramBlock, OramError};
+use crate::path_oram::PathOram;
+use crate::path_oram::{DEFAULT_RECURSION_CUTOFF, DEFAULT_STASH_OVERFLOW_SIZE};
+use crate::StashSize;
+use crate::{Address, BlockSize, BucketSize, Oram, OramBlock, OramError, RecursionCutoff};
 use duplicate::duplicate_item;
 use rand::{
     distributions::{Distribution, Standard},
@@ -43,8 +44,13 @@ pub trait Testable {
 )]
 impl<V: OramBlock> Testable for database_type<V> {}
 impl<DB> Testable for LinearTimeOram<DB> {}
-impl<V: OramBlock, const Z: BucketSize, const AB: BlockSize, const RT: RecursionThreshold> Testable
-    for PathOram<V, Z, AB, RT>
+impl<
+        V: OramBlock,
+        const Z: BucketSize,
+        const AB: BlockSize,
+        const RT: RecursionCutoff,
+        const SO: StashSize,
+    > Testable for PathOram<V, Z, AB, RT, SO>
 {
 }
 
@@ -220,7 +226,7 @@ pub(crate) struct StashSizeMonitor<T> {
 impl<T> Testable for StashSizeMonitor<T> {}
 
 pub(crate) type VecStashSizeMonitor<V, const Z: BucketSize, const AB: BlockSize> =
-    StashSizeMonitor<PathOram<V, Z, AB, DEFAULT_RECURSION_THRESHOLD>>;
+    StashSizeMonitor<PathOram<V, Z, AB, DEFAULT_RECURSION_CUTOFF, DEFAULT_STASH_OVERFLOW_SIZE>>;
 
 impl<V: OramBlock, const Z: BucketSize, const AB: BlockSize> Oram<V>
     for VecStashSizeMonitor<V, Z, AB>
@@ -248,7 +254,9 @@ pub(crate) struct ConstantOccupancyMonitor<T> {
 impl<T> Testable for ConstantOccupancyMonitor<T> {}
 
 pub(crate) type VecConstantOccupancyMonitor<V, const Z: BucketSize, const AB: BlockSize> =
-    ConstantOccupancyMonitor<PathOram<V, Z, AB, DEFAULT_RECURSION_THRESHOLD>>;
+    ConstantOccupancyMonitor<
+        PathOram<V, Z, AB, DEFAULT_RECURSION_CUTOFF, DEFAULT_STASH_OVERFLOW_SIZE>,
+    >;
 
 impl<V: OramBlock, const Z: BucketSize, const AB: BlockSize> Oram<V>
     for VecConstantOccupancyMonitor<V, Z, AB>
@@ -282,7 +290,9 @@ pub(crate) struct PhysicalAccessCountMonitor<T> {
 impl<T> Testable for PhysicalAccessCountMonitor<T> {}
 
 pub(crate) type VecPhysicalAccessCountMonitor<V, const Z: BucketSize, const AB: BlockSize> =
-    PhysicalAccessCountMonitor<PathOram<V, Z, AB, DEFAULT_RECURSION_THRESHOLD>>;
+    PhysicalAccessCountMonitor<
+        PathOram<V, Z, AB, DEFAULT_RECURSION_CUTOFF, DEFAULT_STASH_OVERFLOW_SIZE>,
+    >;
 
 impl<V: OramBlock, const Z: BucketSize, const AB: BlockSize> Oram<V>
     for VecPhysicalAccessCountMonitor<V, Z, AB>


### PR DESCRIPTION
Based on #45 (and earlier). 

- For advanced users, added a description of Path ORAM parameters and how to set them if desired. 
- Exposed the stash overflow size as a parameter.