### PR TITLE
Added to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,54 @@
 ## oram ![Build Status](https://github.com/facebook/oram/workflows/CI/badge.svg)
 
+This library implements an Oblivious RAM (ORAM) for secure enclave applications.
+
+ORAM can be used to reduce the information (including memory access patterns)
+visible to an attacker who has access to the enclave's host system.
+
+This crate assumes that ORAM clients are running inside a secure enclave architecture that provides memory encryption.
+It does not perform encryption-on-write and thus is **not** secure without memory encryption.
+
+⚠️ **Warning**: This implementation has not been audited and is not ready for use in a real system. Use at your own risk!
+
+Documentation
+-------------
+
+TODO link to docs.rs page after the crate is published.
+
+Installation
+------------
+
+TODO after crate is published
+
+### Minimum Supported Rust Version
+
+TODO
+
+Resources
+---------
+
+- [Original Path ORAM paper](https://eprint.iacr.org/2013/280.pdf), which introduced the standard "vanilla" variant of Path ORAM on which this library is based.
+- [Path ORAM retrospective paper](http://elaineshi.com/docs/pathoram-retro.pdf), containing a high-level overview of developments related to Path ORAM.
+- [Oblix paper](https://people.eecs.berkeley.edu/~raluca/oblix.pdf), which describes the oblivious stash data structure this library implements. 
+
+Contributors
+------------
+
+The authors of this code are Spencer Peters ([@spencerpeters](https://github.com/spencerpeters)) and Kevin Lewi
+([@kevinlewi](https://github.com/kevinlewi)).
+To learn more about contributing to this project, [see this document](./CONTRIBUTING.md).
+
+Code Organization
+--------------------
+Within `src/`:
+- `lib.rs` defines the `Oram` trait and public API.
+- `path_oram.rs` defines the main ORAM implementation.
+- `position_map.rs` and `stash.rs` define the oblivious position map and stash respectively.
+- `bucket.rs` defines low-level block and bucket structs.
+- `linear_time_oram.rs` contains a trivial linear-time ORAM implementation used as a base case.
+- `database.rs` defines a simple RAM abstraction (to be removed).
+- `utils.rs` contains utilities related to oblivious sorting and tree index calculations.
+- `test_utils` contains code shared between tests.
 
 License
 -------


### PR DESCRIPTION
Expanded the almost empty README to a nearly complete README in the style of [opaque-ke](https://github.com/facebook/opaque-ke/tree/main). Left TODOs to fill in when the crate is published on crates.io.