### PR TITLE
Stash resizes additively

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 ## oram ![Build Status](https://github.com/facebook/oram/workflows/CI/badge.svg)
 
-<<<<<<< HEAD
 This library implements an Oblivious RAM (ORAM) for secure enclave applications.
 
 This crate assumes that ORAM clients are running inside a secure enclave architecture that provides memory encryption.
@@ -8,26 +7,6 @@ It does not perform encryption-on-write and thus is **not** secure without memor
 
 ⚠️ **Warning**: This implementation has not been audited and is not ready for use in a real system. Use at your own risk!
 
-=======
-This library implements an Oblivious RAM protocol (ORAM) for secure enclave applications.
-
-Background
-----------
-
-An ORAM is an indexed datastore that is backed by local memory,
-but hidden even from an attacker observing that memory.
-More precisely, an attacker outside the enclave can determine (by observing memory accesses)
-when an ORAM access occurs,
-but cannot learn anything about the access type (read versus write), the data read or written,
-or the index accessed. Using ORAM, an enclave application can safely make secret-dependent ORAM accesses.
-In contrast, secret-dependent *memory* accesses, even to encrypted memory, can leak enclave secrets.
-
-This crate assumes that ORAM clients are running inside a secure enclave architecture that provides memory encryption.
-such as [Intel SGX](https://www.intel.com/content/www/us/en/developer/tools/software-guard-extensions/overview.html)
-or [AMD SEV](https://www.amd.com/en/developer/sev.html).
-It does not perform encryption-on-write and thus is **not** secure without memory encryption.
-
->>>>>>> aafe5d2 (Added to README)
 Documentation
 -------------
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,8 @@
 
 //! An implementation of Oblivious RAM (ORAM) for the secure enclave setting.
 //!
+//! ⚠️ **Warning**: This implementation has not been audited and is not ready for use in a real system. Use at your own risk!
+//!
 //! # Overview
 //!
 //! This crate implements an oblivious RAM protocol (ORAM) for (secure) enclave applications.


### PR DESCRIPTION
Based on #47 and earlier. 

Before: On overflow, the size of the stash doubled. This is an aggressive resize and would affect performance a lot.
After: On overflow, the size of the stash increases by STASH_GROWTH_INCREMENT=10 blocks.

Along the way, fixed a bug occurring in the call to `ObliviousStash::write_to_path` in which an overflow occurs. The bug caused a given block to be assigned to multiple buckets, breaking correctness. This should have been caught by testing with the appropriate parameters, and I added an issue to add tests across more parameter values (#49).