### PR TITLE
Added tests for non-default parameters

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -147,7 +147,7 @@ impl<V: OramBlock> Oram<V> for database_type<V> {
 #[cfg(test)]
 mod tests {
     use super::{CountAccessesDatabase, Database, SimpleDatabase};
-    use crate::{bucket::BlockValue, test_utils::*, BlockSize};
+    use crate::{bucket::BlockValue, test_utils::*};
     use std::mem;
 
     #[test]
@@ -164,9 +164,6 @@ mod tests {
         }
     }
 
-    type TestingSimpleDatabase<const B: BlockSize, V> = SimpleDatabase<V>;
-    type TestingCountAccessesDatabase<const B: BlockSize, V> = CountAccessesDatabase<V>;
-
-    create_correctness_tests_for_oram_type!(TestingSimpleDatabase, BlockValue);
-    create_correctness_tests_for_oram_type!(TestingCountAccessesDatabase, BlockValue);
+    create_correctness_tests_for_oram_type!(SimpleDatabase);
+    create_correctness_tests_for_oram_type!(CountAccessesDatabase);
 }

--- a/src/linear_time_oram.rs
+++ b/src/linear_time_oram.rs
@@ -67,9 +67,9 @@ impl<V: OramBlock, DB: Database<V>> Oram<V> for LinearTimeOram<DB> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{bucket::BlockValue, database::CountAccessesDatabase, test_utils::*, BlockSize};
+    use crate::{bucket::BlockValue, database::CountAccessesDatabase, test_utils::*};
 
-    type ConcreteLinearTimeOram<const B: BlockSize, V> = LinearTimeOram<CountAccessesDatabase<V>>;
+    type ConcreteLinearTimeOram<V> = LinearTimeOram<CountAccessesDatabase<V>>;
 
-    create_correctness_tests_for_oram_type!(ConcreteLinearTimeOram, BlockValue);
+    create_correctness_tests_for_oram_type!(ConcreteLinearTimeOram);
 }


### PR DESCRIPTION
Based on #50 and earlier.

Added tests for non-default parameters, updated the default parameters to the values I arrived on through my performance explorations, and significantly simplified the testing code as follows.
- Removed "development" tests, specifically the constant occupancy tests and physical access count tests, that made internal sanity checks.
- Removed redundant "position map" tests that differed from the main Path ORAM tests only in the ORAM block value.
- Removed the access pattern statistics tests.

I think this last removal is the right thing to do although not completely obvious. Essentially, this is for the same reason that I plan to remove the `Database` trait in the next PR. The access pattern statistics tests are intended to increase confidence in the obliviousness of the implementation. However, accesses to the Path ORAM tree represent only a small fraction of the accesses to local memory, so sanity checking their distribution falls well short of sanity checking the complete distribution of memory accesses. For this reason, I think they are not worth the additional complexity. Removing them also makes it easier to get rid of `Database`. I think if we end up adding a memory abstraction that, unlike `Database` currently, actually does intermediate all Path ORAM memory accesses, then meaningful statistical tests access pattern will again become possible, and we can revisit this question.