### PR TITLE
Removed alignment directives

### DIFF
--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -21,7 +21,6 @@ use crate::{utils::TreeIndex, Address};
 use subtle::ConstantTimeEq;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[repr(align(64))]
 /// An `OramBlock` consisting of unstructured bytes.
 pub struct BlockValue<const B: BlockSize>([u8; B]);
 
@@ -155,7 +154,6 @@ impl<const B: BlockSize> Distribution<PositionBlock<B>> for Standard {
 
 impl<const B: BlockSize> OramBlock for PositionBlock<B> {}
 
-#[repr(align(4096))]
 #[derive(Clone, Copy, PartialEq)]
 /// A Path ORAM bucket.
 pub struct Bucket<V: OramBlock, const Z: BucketSize> {


### PR DESCRIPTION
Based on #57 and earlier. Removed the #[(repr(align(64))] directive from `BlockValue`, and removed the #[repr(align(4096))] directive from `Bucket`. 

My explorations found that these alignment directives did not noticeably increase performance, even when blocks were 64 bytes and buckets were 4096 bytes. However, when blocks are not 64 bytes or buckets are not 4096 bytes, they increase the ORAM's memory footprint. (It doesn't really matter, but this noticeably impacts ORAM initialization time.) And since ORAM blocks have metadata, forcing ORAM buckets to be 4096 bytes forces the data they store to have an unusual size, which would only be worth it if alignment substantially improved performance, which it doesn't! :) Hence I feel the best approach is to abandon all attempts at alignment, which is what I'm doing here.