### PR TITLE
Fixed oblivious stash bug

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -25,19 +25,18 @@ pub(crate) trait CompleteBinaryTreeIndex
 where
     Self: Sized,
 {
-    fn node_on_path(&self, depth: TreeHeight, height: TreeHeight) -> Self;
+    fn ct_node_on_path(&self, depth: TreeHeight, height: TreeHeight) -> Self;
     fn random_leaf<R: RngCore + CryptoRng>(
         tree_height: TreeHeight,
         rng: &mut R,
     ) -> Result<Self, TryFromIntError>;
     fn ct_depth(&self) -> TreeHeight;
     fn is_leaf(&self, height: TreeHeight) -> bool;
-    fn ct_common_ancestor_of_two_leaves(&self, other: Self) -> Self;
 }
 
 impl CompleteBinaryTreeIndex for TreeIndex {
     // A TreeIndex can have any nonzero value.
-    fn node_on_path(&self, depth: TreeHeight, height: TreeHeight) -> Self {
+    fn ct_node_on_path(&self, depth: TreeHeight, height: TreeHeight) -> Self {
         // We maintain the invariant that all TreeIndex values are nonzero.
         assert_ne!(*self, 0);
         // We only call this method when the receiver is a leaf.
@@ -72,19 +71,6 @@ impl CompleteBinaryTreeIndex for TreeIndex {
         assert_ne!(*self, 0);
 
         self.ct_depth() == height
-    }
-
-    fn ct_common_ancestor_of_two_leaves(&self, other: Self) -> Self {
-        // We only call this function on pairs of Path ORAM leaves, which have the same depth.
-        assert!(self.ct_depth() == other.ct_depth());
-
-        let shared_prefix_length = (self ^ other).leading_zeros();
-        let common_ancestor = self >> (Self::BITS - shared_prefix_length);
-
-        // Since the input leaves are nonzero, the output must also be nonzero.
-        assert_ne!(common_ancestor, 0);
-
-        common_ancestor
     }
 }
 


### PR DESCRIPTION
Based on #59. 

Before: The oblivious stash was implementing an eviction algorithm that respected the Path ORAM invariant (and thus produced a correct ORAM), but it was not implementing exactly the Path ORAM eviction algorithm. This led to the stash overflowing sooner than it should have.
After: The oblivious stash is implementing exactly the Path ORAM eviction algorithm.

While running a large benchmark (1 million blocks), I noticed that the recursive position map stash overflowed during initialization. This tipped me off to the presence of a bug or similar, since with a stash overflow of 40 blocks, the stash should not overflow more than once in 2^50 accesses. The position map initialization involved only 2^17 accesses. (It's fortunate that I tested small position map blocks so that initialization involved 2^17 accesses instead of 2^10 accesses--in the latter case, I may never have witnessed the overflow!) Re-examining my oblivious stash code, I realized with chagrin that my attempt at clever refactoring of the Path ORAM eviction algorithm was actually incorrect. I fixed it so that it straightforwardly implements the eviction algorithm. Now even with a stash overflow of 10 blocks, there is no overflow.