### PR TITLE
Removed unnecessary copying.

### DIFF
--- a/src/path_oram.rs
+++ b/src/path_oram.rs
@@ -226,18 +226,14 @@ impl<V: OramBlock, const Z: BucketSize, const AB: BlockSize> PathOram<V, Z, AB> 
             .take(last_leaf_index + 1)
             .skip(first_leaf_index)
         {
-            let mut bucket_to_write = Bucket::<V, Z>::default();
             for slot_index in 0..addresses_per_leaf {
                 let address_index = (leaf_index - first_leaf_index) * 2 + slot_index;
-                bucket_to_write.blocks[slot_index] = PathOramBlock::<V> {
+                tree_bucket.blocks[slot_index] = PathOramBlock::<V> {
                     value: V::default(),
                     address: slot_indices_to_addresses[address_index].try_into()?,
                     position: leaf_index.try_into()?,
                 };
             }
-
-            // Write the leaf bucket back to physical memory.
-            *tree_bucket = bucket_to_write;
         }
 
         // The address block size might not divide the block capacity.

--- a/src/stash.rs
+++ b/src/stash.rs
@@ -142,15 +142,13 @@ impl<V: OramBlock> ObliviousStash<V> {
 
         // Write the first Z * height blocks into slots in the tree
         for depth in 0..=height {
-            let mut new_bucket: Bucket<V, Z> = Bucket::default();
-
+            let bucket_to_write =
+                &mut physical_memory[usize::try_from(position.ct_node_on_path(depth, height))?];
             for slot_number in 0..Z {
                 let stash_index = (usize::try_from(depth)?) * Z + slot_number;
 
-                new_bucket.blocks[slot_number] = self.blocks[stash_index];
+                bucket_to_write.blocks[slot_number] = self.blocks[stash_index];
             }
-
-            physical_memory[usize::try_from(position.ct_node_on_path(depth, height))?] = new_bucket;
         }
 
         Ok(())


### PR DESCRIPTION
Removed code making temporary copies of data that used to be necessary before Database abstraction was removed in 
#57, but are now unnecessary.