### PR TITLE
Fix off-by-one in
  PathOram address bounds check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.81
+          - 1.88
 
     steps:
       - uses: actions/checkout@main

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "oram"
 version = "0.2.0-pre.1"
-rust-version = "1.81"
+rust-version = "1.88"
 edition = "2021"
 repository = "https://github.com/facebook/oram"
 description = "An implementation of Oblivious RAM."

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ oram = "0.2.0-pre.1"
 
 ### Minimum Supported Rust Version
 
-Rust **1.81** or higher.
+Rust **1.88** or higher.
 
 Resources
 ---------

--- a/src/path_oram.rs
+++ b/src/path_oram.rs
@@ -254,7 +254,7 @@ impl<V: OramBlock, const Z: BucketSize, const AB: BlockSize> Oram for PathOram<V
         rng: &mut R,
     ) -> Result<V, OramError> {
         // This operation is not constant-time, but only leaks whether the ORAM index is well-formed or not.
-        if address > self.block_capacity()? {
+        if address >= self.block_capacity()? {
             return Err(OramError::AddressOutOfBoundsError {
                 attempted: address,
                 capacity: self.block_capacity()?,

--- a/src/path_oram.rs
+++ b/src/path_oram.rs
@@ -333,6 +333,16 @@ mod tests {
         random_workload(&mut oram, 1000);
     }
 
+    #[test]
+    fn path_oram_rejects_out_of_bounds_address() {
+        let mut rng = StdRng::seed_from_u64(0);
+        let capacity = 8;
+        let mut oram =
+            PathOram::<BlockValue<1>, 4, 8>::new_with_parameters(capacity, &mut rng, 40, 1)
+                .unwrap();
+        assert!(oram.read(capacity, &mut rng).is_err());
+    }
+
     // This test is #[ignore]'d because it takes about 1 second to run.
     #[test]
     #[ignore]

--- a/src/path_oram.rs
+++ b/src/path_oram.rs
@@ -38,21 +38,21 @@ const LINEAR_TIME_ORAM_CUTOFF: RecursionCutoff = 1 << 10;
 ///
 /// - Block type `V`: the type of elements stored by the ORAM.
 /// - Bucket size `Z`: the number of blocks per Path ORAM bucket.
-///     Must be at least 2. Typical values are 3, 4, or 5.
-///     Along with the overflow size, this value affects the probability
-///     of stash overflow (see below) and should be set with care.
+///   Must be at least 2. Typical values are 3, 4, or 5.
+///   Along with the overflow size, this value affects the probability
+///   of stash overflow (see below) and should be set with care.
 /// - Positions per block `AB`:
-///     The number of positions stored in each block of the recursive position map ORAM.
-///     Must be a power of two and must be at least 2 (otherwise the recursion will not terminate).
-///     Otherwise, can be freely tuned for performance.
-///     Larger `AB` means fewer levels of recursion but higher costs for accessing each level.
+///   The number of positions stored in each block of the recursive position map ORAM.
+///   Must be a power of two and must be at least 2 (otherwise the recursion will not terminate).
+///   Otherwise, can be freely tuned for performance.
+///   Larger `AB` means fewer levels of recursion but higher costs for accessing each level.
 /// - Recursion threshold: the maximum number of position blocks that will be stored in a recursive Path ORAM.
-///     Below this value, the position map will be a linear scanning ORAM.
-///     Can be freely tuned for performance.
-///     A larger values means fewer levels of recursion, but a more expensive base position map.
+///   Below this value, the position map will be a linear scanning ORAM.
+///   Can be freely tuned for performance.
+///   A larger values means fewer levels of recursion, but a more expensive base position map.
 /// - Overflow size: The number of blocks that the stash can store between ORAM accesses without overflowing.
-///     Along with the bucket size, this value affects the probability of stash overflow (see below)
-///     and should be set with care.
+///   Along with the bucket size, this value affects the probability of stash overflow (see below)
+///   and should be set with care.
 ///
 /// ## Security
 ///
@@ -215,7 +215,7 @@ impl<V: OramBlock, const Z: BucketSize, const AB: BlockSize> PathOram<V, Z, AB> 
         let last_leaf_index = (2 * first_leaf_index) - 1;
         let ab_address: Address = AB.try_into()?;
 
-        let num_address_blocks = if block_capacity % ab_address == 0 {
+        let num_address_blocks = if block_capacity.is_multiple_of(ab_address) {
             block_capacity / ab_address
         } else {
             block_capacity / ab_address + 1

--- a/src/position_map.rs
+++ b/src/position_map.rs
@@ -83,7 +83,7 @@ impl<const AB: BlockSize, const Z: BucketSize> PositionMap<AB, Z> {
         let ab_address: Address = AB.try_into()?;
         if number_of_addresses / ab_address <= recursion_cutoff {
             let mut block_capacity = number_of_addresses / ab_address;
-            if number_of_addresses % ab_address > 0 {
+            if !number_of_addresses.is_multiple_of(ab_address) {
                 block_capacity += 1;
             }
             Ok(Self::Base(LinearTimeOram::new(block_capacity)?))


### PR DESCRIPTION
Fix an off-by-one error in the PathOram address bounds check. Depends on #76.

## Summary
- `PathOram::access` used `address > capacity` which allowed access at `address == capacity` (one past the valid range `0..capacity-1`).
- `LinearTimeOram::access` already correctly uses strict `<` via `ct_lt`. This aligns `PathOram` by changing `>` to `>=`.
- Adds a regression test asserting that `address == capacity` returns `AddressOutOfBoundsError`.

## Test plan
- [x] New test `path_oram_rejects_out_of_bounds_address` passes
- [x] All existing tests pass (`cargo test`)
